### PR TITLE
Fix cross-platform CI build blockers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - dev
-      - 'codex/**'
-  pull_request:
-    branches:
-      - dev
-  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - dev
+      - 'codex/**'
+  pull_request:
+    branches:
+      - dev
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '9.0.x'
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Engine/Source/ThirdParty/freetype"]
 	path = Engine/Source/ThirdParty/freetype/src
 	url = https://github.com/freetype/freetype.git
+[submodule "Engine/Source/ThirdParty/DirectXShaderCompiler"]
+	path = Engine/Source/ThirdParty/DirectXShaderCompiler
+	url = https://github.com/microsoft/DirectXShaderCompiler.git

--- a/Engine/Source/Runtime/Core/Private/Exception.cpp
+++ b/Engine/Source/Runtime/Core/Private/Exception.cpp
@@ -42,8 +42,9 @@ namespace Ayla
 			}
 
 #if __has_include(<stacktrace>)
-			auto ss = std::format("{}", m_Stacktrace);
-			Composed += String::Format(TEXT("--- End of inner exception stack trace ---\n{} in "), String::FromCodepage(ss));
+			std::ostringstream ss;
+			ss << m_Stacktrace;
+			Composed += String::Format(TEXT("--- End of inner exception stack trace ---\n{} in "), String::FromCodepage(ss.str()));
 #else
 			Composed += String::Format(TEXT("--- End of inner exception stack trace ---\n"));
 #endif
@@ -52,8 +53,9 @@ namespace Ayla
 		else
 		{
 #if __has_include(<stacktrace>)
-			auto ss = std::format("{}", m_Stacktrace);
-			return String::Format(TEXT("{}: {}\n{}"), String::FromCodepage(typeid(*this).name()), m_Message, String::FromCodepage(ss));
+			std::ostringstream ss;
+			ss << m_Stacktrace;
+			return String::Format(TEXT("{}: {}\n{}"), String::FromCodepage(typeid(*this).name()), m_Message, String::FromCodepage(ss.str()));
 #else
 			return String::Format(TEXT("{}: {}"), String::FromCodepage(typeid(*this).name()), m_Message);
 #endif

--- a/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Common.inl
+++ b/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Common.inl
@@ -104,7 +104,7 @@ namespace Ayla
 		}
 		else
 		{
-			throw SocketException(static_cast<SocketError>(WSAEAFNOSUPPORT));
+			throw SocketException(SocketError::AddressFamilyNotSupported);
 		}
 	}
 }

--- a/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
+++ b/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
@@ -147,6 +147,7 @@ namespace Ayla
 				io_uring_sqe* sqe = io_uring_get_sqe(&m_Ring);
 				if (sqe == nullptr)
 				{
+					errno = EAGAIN;
 					return false;
 				}
 
@@ -156,7 +157,6 @@ namespace Ayla
 				if (submitResult < 0)
 				{
 					errno = -submitResult;
-					operation.release();
 					return false;
 				}
 

--- a/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
+++ b/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
@@ -268,7 +268,7 @@ namespace Ayla
 					return;
 				}
 
-				kevent wakeEvent;
+				struct kevent wakeEvent;
 				EV_SET(&wakeEvent, kWakeIdent, EVFILT_USER, EV_ADD | EV_CLEAR, 0, 0, nullptr);
 				if (kevent(m_Kqueue, &wakeEvent, 1, nullptr, 0, nullptr) != 0)
 				{
@@ -321,7 +321,7 @@ namespace Ayla
 		private:
 			bool Register(OSXSocketOperation* operation) noexcept
 			{
-				kevent event;
+				struct kevent event;
 				EV_SET(&event, operation->GetSocket(), operation->GetFilter(), EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0, operation);
 
 				auto lock = std::unique_lock{ m_KqueueMutex };
@@ -330,7 +330,7 @@ namespace Ayla
 
 			void QueueWakeup() noexcept
 			{
-				kevent event;
+				struct kevent event;
 				EV_SET(&event, kWakeIdent, EVFILT_USER, 0, NOTE_TRIGGER, 0, nullptr);
 
 				auto lock = std::unique_lock{ m_KqueueMutex };
@@ -341,7 +341,7 @@ namespace Ayla
 			{
 				while (true)
 				{
-					kevent event;
+					struct kevent event;
 					int result = kevent(m_Kqueue, nullptr, 0, &event, 1, nullptr);
 					if (result == SOCKET_ERROR)
 					{

--- a/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
+++ b/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
@@ -2,19 +2,411 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/uio.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <stop_token>
+#include <thread>
 #include <tuple>
+#include <utility>
 #include <vector>
+#include "MoveOnlyFunction.h"
+#include "Threading/ThreadPool.h"
+#include "Threading/Tasks/TaskCompletionSource.h"
 #include "Socket.Common.inl"
+
+#if PLATFORM_LINUX
+#include <liburing.h>
+#elif PLATFORM_OSX
+#include <sys/event.h>
+#endif
 
 namespace Ayla
 {
 	inline constexpr int INVALID_SOCKET = -1;
 	inline constexpr int SOCKET_ERROR = -1;
+
+	namespace
+	{
+		inline std::exception_ptr MakeSocketException(int32 error)
+		{
+			return std::make_exception_ptr(SocketException(static_cast<SocketError>(error)));
+		}
+
+		template<class T>
+		void SetSocketException(TaskCompletionSource<T> tcs, int32 error)
+		{
+			tcs.TrySetException(MakeSocketException(error));
+		}
+
+		inline void SetSocketResult(TaskCompletionSource<> tcs)
+		{
+			if (!tcs.GetTask().IsCompleted())
+			{
+				tcs.SetResult();
+			}
+		}
+
+		template<class T, class U>
+		void SetSocketResult(TaskCompletionSource<T> tcs, U&& result)
+		{
+			if (!tcs.GetTask().IsCompleted())
+			{
+				tcs.SetResult(std::forward<U>(result));
+			}
+		}
+
+		inline int32 GetSubmitFailureError() noexcept
+		{
+			return errno != 0 ? errno : EAGAIN;
+		}
+
+#if PLATFORM_LINUX
+		class LinuxSocketOperation
+		{
+			MoveOnlyFunction<void(int32)> m_Completion;
+
+		public:
+			explicit LinuxSocketOperation(MoveOnlyFunction<void(int32)> completion)
+				: m_Completion(std::move(completion))
+			{
+			}
+
+			void Complete(int32 result)
+			{
+				m_Completion(result);
+			}
+		};
+
+		class LinuxSocketAsyncQueue
+		{
+			static constexpr uint32 kQueueDepth = 256;
+
+			io_uring m_Ring;
+			std::mutex m_RingMutex;
+			std::stop_source m_StopSource;
+			std::thread m_DispatchThread;
+			int32 m_InitializationError = 0;
+
+		public:
+			static LinuxSocketAsyncQueue& Get()
+			{
+				static LinuxSocketAsyncQueue queue;
+				return queue;
+			}
+
+			LinuxSocketAsyncQueue()
+			{
+				int initResult = io_uring_queue_init(static_cast<unsigned int>(kQueueDepth), &m_Ring, 0);
+				if (initResult != 0)
+				{
+					m_InitializationError = initResult < 0 ? -initResult : initResult;
+					return;
+				}
+
+				m_DispatchThread = std::thread([this]() { Dispatch(m_StopSource.get_token()); });
+			}
+
+			~LinuxSocketAsyncQueue() noexcept
+			{
+				if (m_InitializationError != 0)
+				{
+					return;
+				}
+
+				m_StopSource.request_stop();
+				QueueWakeup();
+				if (m_DispatchThread.joinable())
+				{
+					m_DispatchThread.join();
+				}
+				io_uring_queue_exit(&m_Ring);
+			}
+
+			template<class TPrepare>
+			bool Submit(TPrepare&& prepare, MoveOnlyFunction<void(int32)> completion)
+			{
+				if (m_InitializationError != 0)
+				{
+					errno = m_InitializationError;
+					return false;
+				}
+
+				auto operation = std::make_unique<LinuxSocketOperation>(std::move(completion));
+
+				auto lock = std::unique_lock{ m_RingMutex };
+				io_uring_sqe* sqe = io_uring_get_sqe(&m_Ring);
+				if (sqe == nullptr)
+				{
+					return false;
+				}
+
+				prepare(sqe);
+				io_uring_sqe_set_data(sqe, operation.get());
+				int submitResult = io_uring_submit(&m_Ring);
+				if (submitResult < 0)
+				{
+					errno = -submitResult;
+					operation.release();
+					return false;
+				}
+
+				operation.release();
+				return true;
+			}
+
+		private:
+			void QueueWakeup() noexcept
+			{
+				auto lock = std::unique_lock{ m_RingMutex };
+				io_uring_sqe* sqe = io_uring_get_sqe(&m_Ring);
+				if (sqe != nullptr)
+				{
+					io_uring_prep_nop(sqe);
+					io_uring_sqe_set_data(sqe, nullptr);
+					io_uring_submit(&m_Ring);
+				}
+			}
+
+			void Dispatch(std::stop_token stopToken)
+			{
+				while (true)
+				{
+					io_uring_cqe* cqe = nullptr;
+					int result = io_uring_wait_cqe(&m_Ring, &cqe);
+					if (result == -EINTR)
+					{
+						continue;
+					}
+
+					if (result != 0)
+					{
+						if (stopToken.stop_requested())
+						{
+							break;
+						}
+						continue;
+					}
+
+					auto* operation = reinterpret_cast<LinuxSocketOperation*>(cqe->user_data);
+					int32 operationResult = static_cast<int32>(cqe->res);
+					io_uring_cqe_seen(&m_Ring, cqe);
+
+					if (operation == nullptr)
+					{
+						if (stopToken.stop_requested())
+						{
+							break;
+						}
+						continue;
+					}
+
+					ThreadPool::QueueUserWorkItem([operation, operationResult]()
+					{
+						std::unique_ptr<LinuxSocketOperation> ownedOperation(operation);
+						ownedOperation->Complete(operationResult);
+					});
+				}
+			}
+		};
+#elif PLATFORM_OSX
+		class OSXSocketOperation
+		{
+			int m_Socket = INVALID_SOCKET;
+			int16 m_Filter = 0;
+			MoveOnlyFunction<bool(int32)> m_Completion;
+
+		public:
+			OSXSocketOperation(int socket, int16 filter, MoveOnlyFunction<bool(int32)> completion)
+				: m_Socket(socket)
+				, m_Filter(filter)
+				, m_Completion(std::move(completion))
+			{
+			}
+
+			int GetSocket() const noexcept { return m_Socket; }
+			int16 GetFilter() const noexcept { return m_Filter; }
+
+			bool Complete(int32 error)
+			{
+				return m_Completion(error);
+			}
+		};
+
+		class OSXSocketAsyncQueue
+		{
+			static constexpr uintptr_t kWakeIdent = 1;
+
+			int m_Kqueue = -1;
+			std::mutex m_KqueueMutex;
+			std::stop_source m_StopSource;
+			std::thread m_DispatchThread;
+			int32 m_InitializationError = 0;
+
+		public:
+			static OSXSocketAsyncQueue& Get()
+			{
+				static OSXSocketAsyncQueue queue;
+				return queue;
+			}
+
+			OSXSocketAsyncQueue()
+			{
+				m_Kqueue = kqueue();
+				if (m_Kqueue < 0)
+				{
+					m_InitializationError = errno;
+					return;
+				}
+
+				kevent wakeEvent;
+				EV_SET(&wakeEvent, kWakeIdent, EVFILT_USER, EV_ADD | EV_CLEAR, 0, 0, nullptr);
+				if (kevent(m_Kqueue, &wakeEvent, 1, nullptr, 0, nullptr) != 0)
+				{
+					m_InitializationError = errno;
+					close(m_Kqueue);
+					m_Kqueue = -1;
+					return;
+				}
+
+				m_DispatchThread = std::thread([this]() { Dispatch(m_StopSource.get_token()); });
+			}
+
+			~OSXSocketAsyncQueue() noexcept
+			{
+				if (m_InitializationError != 0)
+				{
+					return;
+				}
+
+				m_StopSource.request_stop();
+				QueueWakeup();
+				if (m_DispatchThread.joinable())
+				{
+					m_DispatchThread.join();
+				}
+				if (m_Kqueue >= 0)
+				{
+					close(m_Kqueue);
+				}
+			}
+
+			bool Submit(int socket, int16 filter, MoveOnlyFunction<bool(int32)> completion)
+			{
+				if (m_InitializationError != 0)
+				{
+					errno = m_InitializationError;
+					return false;
+				}
+
+				auto operation = std::make_unique<OSXSocketOperation>(socket, filter, std::move(completion));
+				if (!Register(operation.get()))
+				{
+					return false;
+				}
+
+				operation.release();
+				return true;
+			}
+
+		private:
+			bool Register(OSXSocketOperation* operation) noexcept
+			{
+				kevent event;
+				EV_SET(&event, operation->GetSocket(), operation->GetFilter(), EV_ADD | EV_ENABLE | EV_ONESHOT, 0, 0, operation);
+
+				auto lock = std::unique_lock{ m_KqueueMutex };
+				return kevent(m_Kqueue, &event, 1, nullptr, 0, nullptr) == 0;
+			}
+
+			void QueueWakeup() noexcept
+			{
+				kevent event;
+				EV_SET(&event, kWakeIdent, EVFILT_USER, 0, NOTE_TRIGGER, 0, nullptr);
+
+				auto lock = std::unique_lock{ m_KqueueMutex };
+				kevent(m_Kqueue, &event, 1, nullptr, 0, nullptr);
+			}
+
+			void Dispatch(std::stop_token stopToken)
+			{
+				while (true)
+				{
+					kevent event;
+					int result = kevent(m_Kqueue, nullptr, 0, &event, 1, nullptr);
+					if (result == SOCKET_ERROR)
+					{
+						if (errno == EINTR)
+						{
+							continue;
+						}
+						if (stopToken.stop_requested())
+						{
+							break;
+						}
+						continue;
+					}
+
+					if (event.filter == EVFILT_USER)
+					{
+						if (stopToken.stop_requested())
+						{
+							break;
+						}
+						continue;
+					}
+
+					auto* operation = reinterpret_cast<OSXSocketOperation*>(event.udata);
+					if (operation == nullptr)
+					{
+						continue;
+					}
+
+					int32 error = (event.flags & EV_ERROR) != 0 ? static_cast<int32>(event.data) : 0;
+					ThreadPool::QueueUserWorkItem([this, operation, error]()
+					{
+						if (operation->Complete(error))
+						{
+							if (Register(operation))
+							{
+								return;
+							}
+							operation->Complete(errno);
+						}
+						delete operation;
+					});
+				}
+			}
+		};
+
+		inline int SetNonBlocking(int socket)
+		{
+			int flags = fcntl(socket, F_GETFL, 0);
+			if (flags != SOCKET_ERROR)
+			{
+				fcntl(socket, F_SETFL, flags | O_NONBLOCK);
+			}
+			return flags;
+		}
+
+		inline void RestoreBlockingMode(int socket, int flags)
+		{
+			if (flags != SOCKET_ERROR)
+			{
+				fcntl(socket, F_SETFL, flags);
+			}
+		}
+#endif
+	}
 
 	struct Socket::PlatformSocket
 	{
@@ -99,70 +491,498 @@ namespace Ayla
 
 		Task<std::shared_ptr<Socket>> AcceptAsync(std::stop_token cancellationToken)
 		{
-			(void)cancellationToken;
-
-			sockaddr_storage clientAddr;
-			socket_len_type clientAddrLen = sizeof(clientAddr);
-			auto clientSocket = accept(m_Socket, reinterpret_cast<sockaddr*>(&clientAddr), &clientAddrLen);
-			if (clientSocket == INVALID_SOCKET)
+			struct AcceptState
 			{
-				Throw();
+				sockaddr_storage m_Address = {};
+				socklen_t m_AddressLength = static_cast<socklen_t>(sizeof(m_Address));
+			};
+
+			auto tcs = TaskCompletionSource<std::shared_ptr<Socket>>::Create(cancellationToken);
+			auto state = std::make_shared<AcceptState>();
+
+#if PLATFORM_LINUX
+			bool submitted = LinuxSocketAsyncQueue::Get().Submit(
+				[socket = m_Socket, state](io_uring_sqe* sqe)
+				{
+					io_uring_prep_accept(sqe, socket, reinterpret_cast<sockaddr*>(&state->m_Address), &state->m_AddressLength, 0);
+				},
+				[tcs, state](int32 result)
+				{
+					(void)state;
+					if (result < 0)
+					{
+						SetSocketException(tcs, -result);
+						return;
+					}
+
+					SetSocketResult(tcs, Socket::CreateFromPlatformSocket(std::make_unique<PlatformSocket>(result)));
+				});
+#else
+			int previousFlags = SetNonBlocking(m_Socket);
+			if (previousFlags == SOCKET_ERROR)
+			{
+				SetSocketException(tcs, errno);
+				return tcs.GetTask();
 			}
 
-			co_return CreateFromPlatformSocket(std::make_unique<PlatformSocket>(clientSocket));
+			bool submitted = OSXSocketAsyncQueue::Get().Submit(m_Socket, EVFILT_READ,
+				[socket = m_Socket, tcs, state, previousFlags](int32 eventError) mutable
+				{
+					if (eventError != 0)
+					{
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, eventError);
+						return false;
+					}
+
+					auto clientSocket = accept(socket, reinterpret_cast<sockaddr*>(&state->m_Address), &state->m_AddressLength);
+					if (clientSocket == INVALID_SOCKET)
+					{
+						if (errno == EAGAIN || errno == EWOULDBLOCK)
+						{
+							return true;
+						}
+
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, errno);
+						return false;
+					}
+
+					RestoreBlockingMode(socket, previousFlags);
+					SetSocketResult(tcs, Socket::CreateFromPlatformSocket(std::make_unique<PlatformSocket>(clientSocket)));
+					return false;
+				});
+#endif
+
+			if (!submitted)
+			{
+#if PLATFORM_OSX
+				RestoreBlockingMode(m_Socket, previousFlags);
+#endif
+				SetSocketException(tcs, GetSubmitFailureError());
+			}
+
+			return tcs.GetTask();
 		}
 
 		Task<> ConnectAsync(const IPEndPoint& remoteEP, std::stop_token cancellationToken)
 		{
-			(void)cancellationToken;
+			struct ConnectState
+			{
+				sockaddr_storage m_Address = {};
+				socklen_t m_AddressLength = 0;
+			};
 
-			sockaddr_storage addr;
-			int addrLen = IPEndPointToSockAddr(remoteEP, addr);
-			int result = connect(m_Socket, reinterpret_cast<sockaddr*>(&addr), addrLen);
-			ThrowIfFailure(result);
-			m_IsConnected = true;
-			co_return;
+			auto tcs = TaskCompletionSource<>::Create(cancellationToken);
+			auto state = std::make_shared<ConnectState>();
+			state->m_AddressLength = static_cast<socklen_t>(IPEndPointToSockAddr(remoteEP, state->m_Address));
+
+#if PLATFORM_LINUX
+			bool submitted = LinuxSocketAsyncQueue::Get().Submit(
+				[socket = m_Socket, state](io_uring_sqe* sqe)
+				{
+					io_uring_prep_connect(sqe, socket, reinterpret_cast<sockaddr*>(&state->m_Address), state->m_AddressLength);
+				},
+				[this, tcs, state](int32 result)
+				{
+					(void)state;
+					if (result < 0)
+					{
+						SetSocketException(tcs, -result);
+						return;
+					}
+
+					m_IsConnected = true;
+					SetSocketResult(tcs);
+				});
+#else
+			int previousFlags = SetNonBlocking(m_Socket);
+			if (previousFlags == SOCKET_ERROR)
+			{
+				SetSocketException(tcs, errno);
+				return tcs.GetTask();
+			}
+
+			int result = connect(m_Socket, reinterpret_cast<sockaddr*>(&state->m_Address), state->m_AddressLength);
+			if (result == 0)
+			{
+				RestoreBlockingMode(m_Socket, previousFlags);
+				m_IsConnected = true;
+				SetSocketResult(tcs);
+				return tcs.GetTask();
+			}
+
+			if (errno != EINPROGRESS)
+			{
+				int32 error = errno;
+				RestoreBlockingMode(m_Socket, previousFlags);
+				SetSocketException(tcs, error);
+				return tcs.GetTask();
+			}
+
+			bool submitted = OSXSocketAsyncQueue::Get().Submit(m_Socket, EVFILT_WRITE,
+				[this, tcs, previousFlags](int32 eventError)
+				{
+					RestoreBlockingMode(m_Socket, previousFlags);
+					if (eventError != 0)
+					{
+						SetSocketException(tcs, eventError);
+						return false;
+					}
+
+					int socketError = 0;
+					socklen_t socketErrorLength = sizeof(socketError);
+					if (getsockopt(m_Socket, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLength) == SOCKET_ERROR)
+					{
+						SetSocketException(tcs, errno);
+						return false;
+					}
+
+					if (socketError != 0)
+					{
+						SetSocketException(tcs, socketError);
+						return false;
+					}
+
+					m_IsConnected = true;
+					SetSocketResult(tcs);
+					return false;
+				});
+#endif
+
+			if (!submitted)
+			{
+#if PLATFORM_OSX
+				RestoreBlockingMode(m_Socket, previousFlags);
+#endif
+				SetSocketException(tcs, GetSubmitFailureError());
+			}
+
+			return tcs.GetTask();
 		}
 
 		Task<size_t> SendAsync(std::span<const uint8> buffer, std::stop_token cancellationToken)
 		{
-			(void)cancellationToken;
+			auto tcs = TaskCompletionSource<size_t>::Create(cancellationToken);
+			auto sendBuffer = std::make_shared<std::vector<uint8>>(buffer.begin(), buffer.end());
 
-			auto result = send(m_Socket, buffer.data(), buffer.size_bytes(), 0);
-			ThrowIfFailure(result);
-			co_return static_cast<size_t>(result);
+#if PLATFORM_LINUX
+			bool submitted = LinuxSocketAsyncQueue::Get().Submit(
+				[socket = m_Socket, sendBuffer](io_uring_sqe* sqe)
+				{
+					io_uring_prep_send(sqe, socket, sendBuffer->data(), sendBuffer->size(), 0);
+				},
+				[tcs, sendBuffer](int32 result)
+				{
+					(void)sendBuffer;
+					if (result < 0)
+					{
+						SetSocketException(tcs, -result);
+						return;
+					}
+
+					SetSocketResult(tcs, static_cast<size_t>(result));
+				});
+#else
+			int previousFlags = SetNonBlocking(m_Socket);
+			if (previousFlags == SOCKET_ERROR)
+			{
+				SetSocketException(tcs, errno);
+				return tcs.GetTask();
+			}
+
+			bool submitted = OSXSocketAsyncQueue::Get().Submit(m_Socket, EVFILT_WRITE,
+				[socket = m_Socket, tcs, sendBuffer, previousFlags](int32 eventError)
+				{
+					if (eventError != 0)
+					{
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, eventError);
+						return false;
+					}
+
+					auto result = send(socket, sendBuffer->data(), sendBuffer->size(), 0);
+					if (result == SOCKET_ERROR)
+					{
+						if (errno == EAGAIN || errno == EWOULDBLOCK)
+						{
+							return true;
+						}
+
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, errno);
+						return false;
+					}
+
+					RestoreBlockingMode(socket, previousFlags);
+					SetSocketResult(tcs, static_cast<size_t>(result));
+					return false;
+				});
+#endif
+
+			if (!submitted)
+			{
+#if PLATFORM_OSX
+				RestoreBlockingMode(m_Socket, previousFlags);
+#endif
+				SetSocketException(tcs, GetSubmitFailureError());
+			}
+
+			return tcs.GetTask();
 		}
 
 		Task<size_t> ReceiveAsync(std::span<uint8> buffer, std::stop_token cancellationToken)
 		{
-			(void)cancellationToken;
+			auto tcs = TaskCompletionSource<size_t>::Create(cancellationToken);
 
-			auto result = recv(m_Socket, buffer.data(), buffer.size_bytes(), 0);
-			ThrowIfFailure(result);
-			co_return static_cast<size_t>(result);
+#if PLATFORM_LINUX
+			bool submitted = LinuxSocketAsyncQueue::Get().Submit(
+				[socket = m_Socket, buffer](io_uring_sqe* sqe)
+				{
+					io_uring_prep_recv(sqe, socket, buffer.data(), buffer.size_bytes(), 0);
+				},
+				[tcs](int32 result)
+				{
+					if (result < 0)
+					{
+						SetSocketException(tcs, -result);
+						return;
+					}
+
+					SetSocketResult(tcs, static_cast<size_t>(result));
+				});
+#else
+			int previousFlags = SetNonBlocking(m_Socket);
+			if (previousFlags == SOCKET_ERROR)
+			{
+				SetSocketException(tcs, errno);
+				return tcs.GetTask();
+			}
+
+			bool submitted = OSXSocketAsyncQueue::Get().Submit(m_Socket, EVFILT_READ,
+				[socket = m_Socket, tcs, buffer, previousFlags](int32 eventError)
+				{
+					if (eventError != 0)
+					{
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, eventError);
+						return false;
+					}
+
+					auto result = recv(socket, buffer.data(), buffer.size_bytes(), 0);
+					if (result == SOCKET_ERROR)
+					{
+						if (errno == EAGAIN || errno == EWOULDBLOCK)
+						{
+							return true;
+						}
+
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, errno);
+						return false;
+					}
+
+					RestoreBlockingMode(socket, previousFlags);
+					SetSocketResult(tcs, static_cast<size_t>(result));
+					return false;
+				});
+#endif
+
+			if (!submitted)
+			{
+#if PLATFORM_OSX
+				RestoreBlockingMode(m_Socket, previousFlags);
+#endif
+				SetSocketException(tcs, GetSubmitFailureError());
+			}
+
+			return tcs.GetTask();
 		}
 
 		Task<size_t> SendToAsync(std::span<const uint8> buffer, const IPEndPoint& remoteEP, std::stop_token cancellationToken)
 		{
-			(void)cancellationToken;
+			struct SendMessageState
+			{
+				std::vector<uint8> m_Buffer;
+				sockaddr_storage m_Address = {};
+				socklen_t m_AddressLength = 0;
+				iovec m_Iov = {};
+				msghdr m_Message = {};
 
-			sockaddr_storage addr;
-			int addrLen = IPEndPointToSockAddr(remoteEP, addr);
-			auto result = sendto(m_Socket, buffer.data(), buffer.size_bytes(), 0, reinterpret_cast<sockaddr*>(&addr), addrLen);
-			ThrowIfFailure(result);
-			co_return static_cast<size_t>(result);
+				SendMessageState(std::span<const uint8> buffer, const IPEndPoint& remoteEP)
+					: m_Buffer(buffer.begin(), buffer.end())
+				{
+					m_AddressLength = static_cast<socklen_t>(IPEndPointToSockAddr(remoteEP, m_Address));
+					m_Iov =
+					{
+						.iov_base = m_Buffer.data(),
+						.iov_len = m_Buffer.size()
+					};
+					m_Message.msg_name = &m_Address;
+					m_Message.msg_namelen = m_AddressLength;
+					m_Message.msg_iov = &m_Iov;
+					m_Message.msg_iovlen = 1;
+				}
+			};
+
+			auto tcs = TaskCompletionSource<size_t>::Create(cancellationToken);
+			auto state = std::make_shared<SendMessageState>(buffer, remoteEP);
+
+#if PLATFORM_LINUX
+			bool submitted = LinuxSocketAsyncQueue::Get().Submit(
+				[socket = m_Socket, state](io_uring_sqe* sqe)
+				{
+					io_uring_prep_sendmsg(sqe, socket, &state->m_Message, 0);
+				},
+				[tcs, state](int32 result)
+				{
+					(void)state;
+					if (result < 0)
+					{
+						SetSocketException(tcs, -result);
+						return;
+					}
+
+					SetSocketResult(tcs, static_cast<size_t>(result));
+				});
+#else
+			int previousFlags = SetNonBlocking(m_Socket);
+			if (previousFlags == SOCKET_ERROR)
+			{
+				SetSocketException(tcs, errno);
+				return tcs.GetTask();
+			}
+
+			bool submitted = OSXSocketAsyncQueue::Get().Submit(m_Socket, EVFILT_WRITE,
+				[socket = m_Socket, tcs, state, previousFlags](int32 eventError)
+				{
+					if (eventError != 0)
+					{
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, eventError);
+						return false;
+					}
+
+					auto result = sendto(socket, state->m_Buffer.data(), state->m_Buffer.size(), 0, reinterpret_cast<sockaddr*>(&state->m_Address), state->m_AddressLength);
+					if (result == SOCKET_ERROR)
+					{
+						if (errno == EAGAIN || errno == EWOULDBLOCK)
+						{
+							return true;
+						}
+
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, errno);
+						return false;
+					}
+
+					RestoreBlockingMode(socket, previousFlags);
+					SetSocketResult(tcs, static_cast<size_t>(result));
+					return false;
+				});
+#endif
+
+			if (!submitted)
+			{
+#if PLATFORM_OSX
+				RestoreBlockingMode(m_Socket, previousFlags);
+#endif
+				SetSocketException(tcs, GetSubmitFailureError());
+			}
+
+			return tcs.GetTask();
 		}
 
 		Task<size_t> ReceiveFromAsync(std::span<uint8> buffer, IPEndPoint& remoteEP, std::stop_token cancellationToken)
 		{
-			(void)cancellationToken;
+			struct ReceiveMessageState
+			{
+				sockaddr_storage m_Address = {};
+				socklen_t m_AddressLength = static_cast<socklen_t>(sizeof(m_Address));
+				iovec m_Iov = {};
+				msghdr m_Message = {};
 
-			sockaddr_storage addr;
-			socket_len_type addrLen = sizeof(addr);
-			auto result = recvfrom(m_Socket, buffer.data(), buffer.size_bytes(), 0, reinterpret_cast<sockaddr*>(&addr), &addrLen);
-			ThrowIfFailure(result);
-			remoteEP = SockAddrToIPEndPoint(addr);
-			co_return static_cast<size_t>(result);
+				explicit ReceiveMessageState(std::span<uint8> buffer)
+				{
+					m_Iov =
+					{
+						.iov_base = buffer.data(),
+						.iov_len = buffer.size_bytes()
+					};
+					m_Message.msg_name = &m_Address;
+					m_Message.msg_namelen = m_AddressLength;
+					m_Message.msg_iov = &m_Iov;
+					m_Message.msg_iovlen = 1;
+				}
+			};
+
+			auto tcs = TaskCompletionSource<size_t>::Create(cancellationToken);
+			auto state = std::make_shared<ReceiveMessageState>(buffer);
+
+#if PLATFORM_LINUX
+			bool submitted = LinuxSocketAsyncQueue::Get().Submit(
+				[socket = m_Socket, state](io_uring_sqe* sqe)
+				{
+					io_uring_prep_recvmsg(sqe, socket, &state->m_Message, 0);
+				},
+				[tcs, state, &remoteEP](int32 result)
+				{
+					if (result < 0)
+					{
+						SetSocketException(tcs, -result);
+						return;
+					}
+
+					remoteEP = SockAddrToIPEndPoint(state->m_Address);
+					SetSocketResult(tcs, static_cast<size_t>(result));
+				});
+#else
+			int previousFlags = SetNonBlocking(m_Socket);
+			if (previousFlags == SOCKET_ERROR)
+			{
+				SetSocketException(tcs, errno);
+				return tcs.GetTask();
+			}
+
+			bool submitted = OSXSocketAsyncQueue::Get().Submit(m_Socket, EVFILT_READ,
+				[socket = m_Socket, tcs, state, &remoteEP, buffer, previousFlags](int32 eventError)
+				{
+					if (eventError != 0)
+					{
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, eventError);
+						return false;
+					}
+
+					auto result = recvfrom(socket, buffer.data(), buffer.size_bytes(), 0, reinterpret_cast<sockaddr*>(&state->m_Address), &state->m_AddressLength);
+					if (result == SOCKET_ERROR)
+					{
+						if (errno == EAGAIN || errno == EWOULDBLOCK)
+						{
+							return true;
+						}
+
+						RestoreBlockingMode(socket, previousFlags);
+						SetSocketException(tcs, errno);
+						return false;
+					}
+
+					RestoreBlockingMode(socket, previousFlags);
+					remoteEP = SockAddrToIPEndPoint(state->m_Address);
+					SetSocketResult(tcs, static_cast<size_t>(result));
+					return false;
+				});
+#endif
+
+			if (!submitted)
+			{
+#if PLATFORM_OSX
+				RestoreBlockingMode(m_Socket, previousFlags);
+#endif
+				SetSocketException(tcs, GetSubmitFailureError());
+			}
+
+			return tcs.GetTask();
 		}
 
 		bool IsConnected() const { return m_IsConnected; }

--- a/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
+++ b/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
@@ -2,6 +2,8 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
 #include <unistd.h>
 #include "Socket.Common.inl"
 

--- a/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
+++ b/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Unix.inl
@@ -2,24 +2,282 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <unistd.h>
+#include <cerrno>
+#include <tuple>
+#include <vector>
 #include "Socket.Common.inl"
 
 namespace Ayla
 {
+	inline constexpr int INVALID_SOCKET = -1;
+	inline constexpr int SOCKET_ERROR = -1;
+
 	struct Socket::PlatformSocket
 	{
+		using socket_len_type = socklen_t;
+
 		const int m_Socket;
+		const AddressFamily m_AddressFamily;
+		const SocketType m_SocketType;
+		bool m_IsBound = false;
+		bool m_IsListening = false;
+		bool m_IsConnected = false;
+
+		static void Initialize()
+		{
+		}
 
 		PlatformSocket(AddressFamily af, SocketType st)
 			: m_Socket{ socket(AddressFamilyToInt32(af), SocketTypeToInt32(st), 0) }
-		{}
+			, m_AddressFamily(af)
+			, m_SocketType(st)
+		{
+			if (m_Socket == INVALID_SOCKET)
+			{
+				Throw();
+			}
+		}
+
+		static std::tuple<AddressFamily, SocketType> GetOptions(int socket)
+		{
+			sockaddr_storage addr;
+			socket_len_type addrLen = sizeof(addr);
+			if (getsockname(socket, reinterpret_cast<sockaddr*>(&addr), &addrLen) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+
+			int socketType;
+			socket_len_type socketTypeLen = sizeof(socketType);
+			if (getsockopt(socket, SOL_SOCKET, SO_TYPE, &socketType, &socketTypeLen) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+
+			return std::make_tuple(Int32ToAddressFamily(addr.ss_family), Int32ToSocketType(socketType));
+		}
+
+		PlatformSocket(int socket, std::tuple<AddressFamily, SocketType> options)
+			: m_Socket(socket)
+			, m_AddressFamily(std::get<0>(options))
+			, m_SocketType(std::get<1>(options))
+			, m_IsConnected(true)
+		{
+		}
+
+		explicit PlatformSocket(int socket)
+			: PlatformSocket(socket, GetOptions(socket))
+		{
+		}
 
 		~PlatformSocket() noexcept
 		{
-			close(m_Socket);
+			if (m_Socket != INVALID_SOCKET)
+			{
+				close(m_Socket);
+			}
+		}
+
+		template<class TResult>
+		static void ThrowIfFailure(TResult resultCode)
+		{
+			if (resultCode == static_cast<TResult>(SOCKET_ERROR))
+			{
+				Throw();
+			}
+		}
+
+		[[noreturn]]
+		static void Throw()
+		{
+			throw SocketException(static_cast<SocketError>(errno));
+		}
+
+		Task<std::shared_ptr<Socket>> AcceptAsync(std::stop_token cancellationToken)
+		{
+			(void)cancellationToken;
+
+			sockaddr_storage clientAddr;
+			socket_len_type clientAddrLen = sizeof(clientAddr);
+			auto clientSocket = accept(m_Socket, reinterpret_cast<sockaddr*>(&clientAddr), &clientAddrLen);
+			if (clientSocket == INVALID_SOCKET)
+			{
+				Throw();
+			}
+
+			co_return CreateFromPlatformSocket(std::make_unique<PlatformSocket>(clientSocket));
+		}
+
+		Task<> ConnectAsync(const IPEndPoint& remoteEP, std::stop_token cancellationToken)
+		{
+			(void)cancellationToken;
+
+			sockaddr_storage addr;
+			int addrLen = IPEndPointToSockAddr(remoteEP, addr);
+			int result = connect(m_Socket, reinterpret_cast<sockaddr*>(&addr), addrLen);
+			ThrowIfFailure(result);
+			m_IsConnected = true;
+			co_return;
+		}
+
+		Task<size_t> SendAsync(std::span<const uint8> buffer, std::stop_token cancellationToken)
+		{
+			(void)cancellationToken;
+
+			auto result = send(m_Socket, buffer.data(), buffer.size_bytes(), 0);
+			ThrowIfFailure(result);
+			co_return static_cast<size_t>(result);
+		}
+
+		Task<size_t> ReceiveAsync(std::span<uint8> buffer, std::stop_token cancellationToken)
+		{
+			(void)cancellationToken;
+
+			auto result = recv(m_Socket, buffer.data(), buffer.size_bytes(), 0);
+			ThrowIfFailure(result);
+			co_return static_cast<size_t>(result);
+		}
+
+		Task<size_t> SendToAsync(std::span<const uint8> buffer, const IPEndPoint& remoteEP, std::stop_token cancellationToken)
+		{
+			(void)cancellationToken;
+
+			sockaddr_storage addr;
+			int addrLen = IPEndPointToSockAddr(remoteEP, addr);
+			auto result = sendto(m_Socket, buffer.data(), buffer.size_bytes(), 0, reinterpret_cast<sockaddr*>(&addr), addrLen);
+			ThrowIfFailure(result);
+			co_return static_cast<size_t>(result);
+		}
+
+		Task<size_t> ReceiveFromAsync(std::span<uint8> buffer, IPEndPoint& remoteEP, std::stop_token cancellationToken)
+		{
+			(void)cancellationToken;
+
+			sockaddr_storage addr;
+			socket_len_type addrLen = sizeof(addr);
+			auto result = recvfrom(m_Socket, buffer.data(), buffer.size_bytes(), 0, reinterpret_cast<sockaddr*>(&addr), &addrLen);
+			ThrowIfFailure(result);
+			remoteEP = SockAddrToIPEndPoint(addr);
+			co_return static_cast<size_t>(result);
+		}
+
+		bool IsConnected() const { return m_IsConnected; }
+		bool IsBound() const { return m_IsBound; }
+		bool IsListening() const { return m_IsListening; }
+		AddressFamily GetAddressFamily() const { return m_AddressFamily; }
+		SocketType GetSocketType() const { return m_SocketType; }
+
+		void SetSocketOption(int32 level, int32 optionName, bool optionValue)
+		{
+			int value = optionValue ? 1 : 0;
+			if (setsockopt(m_Socket, level, optionName, &value, sizeof(value)) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+		}
+
+		void SetSocketOption(int32 level, int32 optionName, int32 optionValue)
+		{
+			if (setsockopt(m_Socket, level, optionName, &optionValue, sizeof(optionValue)) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+		}
+
+		void SetSocketOption(int32 level, int32 optionName, std::span<const uint8> optionValue)
+		{
+			if (setsockopt(m_Socket, level, optionName, optionValue.data(), static_cast<socket_len_type>(optionValue.size_bytes())) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+		}
+
+		bool GetSocketOptionBool(int32 level, int32 optionName) const
+		{
+			int value;
+			socket_len_type valueLen = sizeof(value);
+			if (getsockopt(m_Socket, level, optionName, &value, &valueLen) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+			return value != 0;
+		}
+
+		int32 GetSocketOptionInt32(int32 level, int32 optionName) const
+		{
+			int32 value;
+			socket_len_type valueLen = sizeof(value);
+			if (getsockopt(m_Socket, level, optionName, &value, &valueLen) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+			return value;
+		}
+
+		std::vector<uint8> GetSocketOptionBytes(int32 level, int32 optionName) const
+		{
+			std::vector<uint8> buffer(256);
+			socket_len_type bufferLen = static_cast<socket_len_type>(buffer.size());
+
+			if (getsockopt(m_Socket, level, optionName, buffer.data(), &bufferLen) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+
+			buffer.resize(bufferLen);
+			return buffer;
+		}
+
+		void Shutdown(SocketShutdown how)
+		{
+			if (shutdown(m_Socket, static_cast<int>(how)) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+		}
+
+		int32 GetAvailable() const
+		{
+			int available;
+			if (ioctl(m_Socket, FIONREAD, &available) == SOCKET_ERROR)
+			{
+				Throw();
+			}
+			return available;
+		}
+
+		bool Poll(int32 microSeconds, int32 mode) const
+		{
+			fd_set fds;
+			FD_ZERO(&fds);
+			FD_SET(m_Socket, &fds);
+
+			timeval timeout;
+			timeout.tv_sec = microSeconds / 1000000;
+			timeout.tv_usec = microSeconds % 1000000;
+
+			int result;
+			switch (mode)
+			{
+			case 0:
+				result = select(m_Socket + 1, &fds, nullptr, nullptr, &timeout);
+				break;
+			case 1:
+				result = select(m_Socket + 1, nullptr, &fds, nullptr, &timeout);
+				break;
+			case 2:
+				result = select(m_Socket + 1, nullptr, nullptr, &fds, &timeout);
+				break;
+			default:
+				throw SocketException(SocketError::InvalidArgument);
+			}
+
+			ThrowIfFailure(result);
+			return result > 0;
 		}
 	};
 }

--- a/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Windows.inl
+++ b/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.Windows.inl
@@ -15,6 +15,8 @@ namespace Ayla
 {
 	struct Socket::PlatformSocket
 	{
+		using socket_len_type = int;
+
 		const SOCKET m_Socket;
 		const AddressFamily m_AddressFamily;
 		const SocketType m_SocketType;

--- a/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.cpp
+++ b/Engine/Source/Runtime/Core/Private/Net/Sockets/Socket.cpp
@@ -75,7 +75,7 @@ namespace Ayla
 	{
 		EnsureSocket();
 		sockaddr_storage clientAddr;
-		int clientAddrLen = sizeof(clientAddr);
+		PlatformSocket::socket_len_type clientAddrLen = sizeof(clientAddr);
 		auto clientSocket = accept(m_Socket->m_Socket, reinterpret_cast<sockaddr*>(&clientAddr), &clientAddrLen);
 		if (clientSocket == INVALID_SOCKET)
 		{
@@ -117,7 +117,7 @@ namespace Ayla
 	{
 		EnsureSocket();
 		sockaddr_storage addr;
-		int addrLen = sizeof(addr);
+		PlatformSocket::socket_len_type addrLen = sizeof(addr);
 
 		int result = recvfrom(m_Socket->m_Socket, reinterpret_cast<char*>(buffer.data()),
 			static_cast<int>(buffer.size()), 0, reinterpret_cast<sockaddr*>(&addr), &addrLen);
@@ -193,7 +193,7 @@ namespace Ayla
 	{
 		EnsureSocket();
 		sockaddr_storage addr;
-		int addrLen = sizeof(addr);
+		PlatformSocket::socket_len_type addrLen = sizeof(addr);
 		int result = getsockname(m_Socket->m_Socket, reinterpret_cast<sockaddr*>(&addr), &addrLen);
 		PlatformSocket::ThrowIfFailure(result);
 		return SockAddrToIPEndPoint(addr);
@@ -203,7 +203,7 @@ namespace Ayla
 	{
 		EnsureSocket();
 		sockaddr_storage addr;
-		int addrLen = sizeof(addr);
+		PlatformSocket::socket_len_type addrLen = sizeof(addr);
 		int result = getpeername(m_Socket->m_Socket, reinterpret_cast<sockaddr*>(&addr), &addrLen);
 		PlatformSocket::ThrowIfFailure(result);
 		return SockAddrToIPEndPoint(addr);

--- a/Engine/Source/Runtime/Core/Private/Platform/Linux/LinuxPlatformIO.cpp
+++ b/Engine/Source/Runtime/Core/Private/Platform/Linux/LinuxPlatformIO.cpp
@@ -317,14 +317,22 @@ namespace Ayla
         case FileMode::Truncate:  flags |= O_TRUNC; break;
         }
 
-        switch (InAccessMode)
+        const uint32 accessMode = (uint32)InAccessMode;
+        if (accessMode == (uint32)FileAccessMode::Read)
         {
-        case FileAccessMode::Read:    flags |= O_RDONLY; break;
-        case FileAccessMode::Write:   flags |= O_WRONLY; break;
-        case FileAccessMode::Append:  flags |= O_APPEND | O_CREAT; break;
-        case (FileAccessMode::Read | FileAccessMode::Write):
+            flags |= O_RDONLY;
+        }
+        else if (accessMode == (uint32)FileAccessMode::Write)
+        {
+            flags |= O_WRONLY;
+        }
+        else if (accessMode == (uint32)FileAccessMode::Append)
+        {
+            flags |= O_APPEND | O_CREAT;
+        }
+        else if (accessMode == ((uint32)FileAccessMode::Read | (uint32)FileAccessMode::Write) || accessMode == (uint32)FileAccessMode::All)
+        {
             flags |= O_RDWR;
-            break;
         }
 
         int fd = open(InFilename.AsCodepage().c_str(), flags, 0666);

--- a/Engine/Source/Runtime/Core/Private/Platform/Linux/LinuxPlatformIO.cpp
+++ b/Engine/Source/Runtime/Core/Private/Platform/Linux/LinuxPlatformIO.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright 2020-2025 Aumoa.lib. All right reserved.
+// Copyright 2020-2025 Aumoa.lib. All right reserved.
 
 #include "Platform/Linux/LinuxPlatformIO.h"
 
@@ -20,6 +20,10 @@
 #include <cerrno>
 #include <limits>
 #include <span>
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
 #include <liburing.h>
 
 namespace Ayla
@@ -27,15 +31,24 @@ namespace Ayla
     class IOCompletionPort
     {
     private:
+        struct Completion
+        {
+            IOCompletionOverlapped* m_Overlap = nullptr;
+            size_t m_Bytes = 0;
+            int32 m_Error = 0;
+        };
+
         static constexpr uint32 kUringQueueDepth = 64;
         io_uring m_Ring;
 
-        std::queue<std::pair<IOCompletionOverlapped*, size_t>> m_Overlaps;
+        std::queue<Completion> m_Overlaps;
         std::mutex m_Mutex;
         std::condition_variable m_Cond;
 
+        std::mutex m_RingMutex;
         std::mutex m_CancellationLock;
         std::stop_source m_DispatchCancel;
+        std::thread m_DispatchThread;
 
     public:
         struct scoped_sqe
@@ -46,7 +59,7 @@ namespace Ayla
             scoped_sqe(IOCompletionPort* completionPort)
                 : m_CompletionPort{ completionPort }
             {
-                completionPort->m_Mutex.lock();
+                completionPort->m_RingMutex.lock();
                 m_sqe = io_uring_get_sqe(&completionPort->m_Ring);
             }
 
@@ -62,23 +75,32 @@ namespace Ayla
             {
                 if (m_CompletionPort != nullptr)
                 {
-                    io_uring_submit(&m_CompletionPort->m_Ring);
-                    m_CompletionPort->m_Mutex.unlock();
+                    if (m_sqe != nullptr)
+                    {
+                        io_uring_submit(&m_CompletionPort->m_Ring);
+                    }
+                    m_CompletionPort->m_RingMutex.unlock();
                 }
             }
 
             inline operator io_uring_sqe*() const noexcept { return m_sqe; }
+            inline explicit operator bool() const noexcept { return m_sqe != nullptr; }
         };
 
     public:
         IOCompletionPort()
         {
-            io_uring_queue_init((unsigned int)kUringQueueDepth, &m_Ring, 0);
-            std::thread([this]() { this->io_uring_dispatch(this->m_DispatchCancel.get_token()); }).detach();
+            check(io_uring_queue_init(static_cast<unsigned int>(kUringQueueDepth), &m_Ring, 0) == 0);
+            m_DispatchThread = std::thread([this]() { this->io_uring_dispatch(this->m_DispatchCancel.get_token()); });
         }
 
         ~IOCompletionPort() noexcept
         {
+            RequestStop();
+            if (m_DispatchThread.joinable())
+            {
+                m_DispatchThread.join();
+            }
             io_uring_queue_exit(&m_Ring);
         }
 
@@ -113,27 +135,39 @@ namespace Ayla
                 return false;
             }
 
-            auto [overlap, res] = m_Overlaps.front();
+            auto completion = m_Overlaps.front();
             m_Overlaps.pop();
             lock.unlock();
 
-            if (res >= 0)
+            if (completion.m_Error == 0)
             {
-                overlap->Complete(res);
+                completion.m_Overlap->Complete(completion.m_Bytes);
             }
             else
             {
-                overlap->Failed(res);
+                completion.m_Overlap->Failed(completion.m_Error);
             }
 
             return true;
         }
 
-        void QueueInterruptSignal() noexcept
+        void RequestStop() noexcept
         {
-            auto lock = std::unique_lock{ m_Mutex };
             m_DispatchCancel.request_stop();
+            QueueWakeup();
             m_Cond.notify_all();
+        }
+
+        void QueueWakeup() noexcept
+        {
+            auto lock = std::unique_lock{ m_RingMutex };
+            io_uring_sqe* sqe = io_uring_get_sqe(&m_Ring);
+            if (sqe != nullptr)
+            {
+                io_uring_prep_nop(sqe);
+                io_uring_sqe_set_data(sqe, nullptr);
+                io_uring_submit(&m_Ring);
+            }
         }
         
         void io_uring_dispatch(std::stop_token cancellationToken)
@@ -157,9 +191,26 @@ namespace Ayla
                 else if (i_errno == 0)
                 {
                     auto* overlap = (IOCompletionOverlapped*)cqe->user_data;
-                    auto lock = std::unique_lock{ m_Mutex };
-                    m_Overlaps.emplace(overlap, (size_t)cqe->res);
+                    int32 error = cqe->res < 0 ? static_cast<int32>(-cqe->res) : 0;
+                    size_t bytes = cqe->res < 0 ? 0 : static_cast<size_t>(cqe->res);
                     io_uring_cqe_seen(&this->m_Ring, cqe);
+
+                    if (overlap == nullptr)
+                    {
+                        if (cancellationToken.stop_requested())
+                        {
+                            break;
+                        }
+                        continue;
+                    }
+
+                    auto lock = std::unique_lock{ m_Mutex };
+                    m_Overlaps.emplace(Completion
+                    {
+                        .m_Overlap = overlap,
+                        .m_Bytes = bytes,
+                        .m_Error = error
+                    });
                     m_Cond.notify_one();
                 }
                 else
@@ -231,8 +282,9 @@ namespace Ayla
 
     void LinuxPlatformIO::QueueInterruptSignal(void* handle, int32 size) noexcept
     {
+        (void)size;
         auto iocp = reinterpret_cast<IOCompletionPort*>(handle);
-        iocp->QueueInterruptSignal();
+        iocp->RequestStop();
     }
 
     void LinuxPlatformIO::OpenFileHandle(void*& Handle, String InFilename, FileMode InFileMode, FileAccessMode InAccessMode, FileSharedMode InSharedMode) noexcept
@@ -283,13 +335,13 @@ namespace Ayla
 
     bool LinuxPlatformIO::FlushFileBuffers(void* Handle) noexcept
     {
-        int fd = static_cast<int>(reinterpret_cast<intptr_t>(Handle));
-        return fsync(fd) == 0;
+        auto* socketHandle = reinterpret_cast<SocketHandle*>(Handle);
+        return fsync(socketHandle->m_fd) == 0;
     }
 
     bool LinuxPlatformIO::SetFileSeekPointer(void* Handle, int64 Seekpos, SeekOrigin InOrigin) noexcept
     {
-        int fd = static_cast<int>(reinterpret_cast<intptr_t>(Handle));
+        auto* socketHandle = reinterpret_cast<SocketHandle*>(Handle);
         int whence = SEEK_SET;
         switch (InOrigin)
         {
@@ -297,24 +349,26 @@ namespace Ayla
         case SeekOrigin::Current: whence = SEEK_CUR; break;
         case SeekOrigin::End:     whence = SEEK_END; break;
         }
-        return lseek(fd, Seekpos, whence) != -1;
+        return lseek(socketHandle->m_fd, Seekpos, whence) != -1;
     }
 
     int64 LinuxPlatformIO::GetFileSize(void* Handle) noexcept
     {
-        int fd = static_cast<int>(reinterpret_cast<intptr_t>(Handle));
+        auto* socketHandle = reinterpret_cast<SocketHandle*>(Handle);
         struct stat st;
-        if (fstat(fd, &st) == -1)
+        if (fstat(socketHandle->m_fd, &st) == -1)
         {
             return 0;
         }
         return static_cast<int64>(st.st_size);
     }
 
-    Action<IOCompletionOverlapped*, size_t, int32> LinuxPlatformIO::FileIOWrittenAction(TaskCompletionSource<size_t> TCS, void* WriteIO) noexcept
+    MoveOnlyFunction<void(IOCompletionOverlapped*, size_t, int32)> LinuxPlatformIO::FileIOWrittenAction(TaskCompletionSource<size_t> TCS, void* WriteIO) noexcept
     {
         return [TCS, WriteIO](IOCompletionOverlapped* self, size_t written, int32 err)
         {
+            (void)self;
+            (void)WriteIO;
             if (err)
             {
                 TCS.TrySetException<SystemException>(err);
@@ -330,15 +384,21 @@ namespace Ayla
     {
         auto* socketHandle = reinterpret_cast<SocketHandle*>(handle);
         auto sqe = socketHandle->m_CompletionPort->get_scoped_sqe();
+        if (!sqe)
+        {
+            return false;
+        }
         io_uring_prep_write(sqe, socketHandle->m_fd, inBytes.data(), inBytes.size_bytes(), (__u64)-1);
         io_uring_sqe_set_data(sqe, overlap);
         return true;
     }
 
-    Action<IOCompletionOverlapped*, size_t, int32> LinuxPlatformIO::FileIOReadAction(TaskCompletionSource<size_t> TCS, void* ReadIO) noexcept
+    MoveOnlyFunction<void(IOCompletionOverlapped*, size_t, int32)> LinuxPlatformIO::FileIOReadAction(TaskCompletionSource<size_t> TCS, void* ReadIO) noexcept
     {
         return [TCS, ReadIO](IOCompletionOverlapped* self, size_t read, int32 err)
         {
+            (void)self;
+            (void)ReadIO;
             if (err)
             {
                 TCS.TrySetException<SystemException>(err);
@@ -354,6 +414,10 @@ namespace Ayla
     {
         auto* socketHandle = reinterpret_cast<SocketHandle*>(handle);
         auto sqe = socketHandle->m_CompletionPort->get_scoped_sqe();
+        if (!sqe)
+        {
+            return false;
+        }
         io_uring_prep_read(sqe, socketHandle->m_fd, outBytes.data(), outBytes.size_bytes(), (__u64)-1);
         io_uring_sqe_set_data(sqe, overlap);
         return true;

--- a/Engine/Source/Runtime/Core/Private/Platform/Linux/LinuxPlatformIO.cpp
+++ b/Engine/Source/Runtime/Core/Private/Platform/Linux/LinuxPlatformIO.cpp
@@ -49,6 +49,7 @@ namespace Ayla
         std::mutex m_CancellationLock;
         std::stop_source m_DispatchCancel;
         std::thread m_DispatchThread;
+        int32 m_InitializationError = 0;
 
     public:
         struct scoped_sqe
@@ -59,6 +60,13 @@ namespace Ayla
             scoped_sqe(IOCompletionPort* completionPort)
                 : m_CompletionPort{ completionPort }
             {
+                if (completionPort->m_InitializationError != 0)
+                {
+                    m_CompletionPort = nullptr;
+                    errno = completionPort->m_InitializationError;
+                    return;
+                }
+
                 completionPort->m_RingMutex.lock();
                 m_sqe = io_uring_get_sqe(&completionPort->m_Ring);
             }
@@ -90,12 +98,23 @@ namespace Ayla
     public:
         IOCompletionPort()
         {
-            check(io_uring_queue_init(static_cast<unsigned int>(kUringQueueDepth), &m_Ring, 0) == 0);
+            int initResult = io_uring_queue_init(static_cast<unsigned int>(kUringQueueDepth), &m_Ring, 0);
+            if (initResult != 0)
+            {
+                m_InitializationError = initResult < 0 ? -initResult : initResult;
+                return;
+            }
+
             m_DispatchThread = std::thread([this]() { this->io_uring_dispatch(this->m_DispatchCancel.get_token()); });
         }
 
         ~IOCompletionPort() noexcept
         {
+            if (m_InitializationError != 0)
+            {
+                return;
+            }
+
             RequestStop();
             if (m_DispatchThread.joinable())
             {
@@ -246,7 +265,6 @@ namespace Ayla
 
     void LinuxPlatformIO::InitializeIOCPHandle(void*& Handle) noexcept
     {
-        const uint32 kUringQueueDepth = 64;
         auto* completionPort = new IOCompletionPort();
         Handle = completionPort;
     }

--- a/Engine/Source/Runtime/Core/Private/Platform/OSX/OSXPlatformIO.cpp
+++ b/Engine/Source/Runtime/Core/Private/Platform/OSX/OSXPlatformIO.cpp
@@ -25,17 +25,46 @@
 #include <mutex>
 #include <condition_variable>
 #include <thread>
+#include <vector>
 
 namespace Ayla
 {
     class IOCompletionPort
     {
     private:
+        enum class FileOperation
+        {
+            Read,
+            Write
+        };
+
+        struct Completion
+        {
+            IOCompletionOverlapped* m_Overlap = nullptr;
+            size_t m_Bytes = 0;
+            int32 m_Error = 0;
+        };
+
+        struct FileRequest
+        {
+            FileOperation m_Operation = FileOperation::Read;
+            int m_Fd = -1;
+            const uint8* m_WriteData = nullptr;
+            uint8* m_ReadData = nullptr;
+            size_t m_Size = 0;
+            IOCompletionOverlapped* m_Overlap = nullptr;
+        };
+
         int m_Kqueue;
 
-        std::queue<std::pair<IOCompletionOverlapped*, size_t>> m_Overlaps;
+        std::queue<Completion> m_Overlaps;
         std::mutex m_Mutex;
         std::condition_variable m_Cond;
+
+        std::queue<FileRequest> m_FileRequests;
+        std::mutex m_FileMutex;
+        std::condition_variable m_FileCond;
+        std::vector<std::thread> m_FileWorkers;
 
         std::stop_source m_DispatchCancel;
 
@@ -43,10 +72,24 @@ namespace Ayla
         IOCompletionPort()
         {
             m_Kqueue = kqueue();
+            constexpr size_t kFileWorkerCount = 2;
+            for (size_t i = 0; i < kFileWorkerCount; ++i)
+            {
+                m_FileWorkers.emplace_back([this]() { FileWorker(this->m_DispatchCancel.get_token()); });
+            }
         }
 
         ~IOCompletionPort() noexcept
         {
+            RequestStop();
+            for (auto& worker : m_FileWorkers)
+            {
+                if (worker.joinable())
+                {
+                    worker.join();
+                }
+            }
+
             if (m_Kqueue >= 0)
             {
                 close(m_Kqueue);
@@ -84,34 +127,128 @@ namespace Ayla
                 return false;
             }
 
-            auto [overlap, res] = m_Overlaps.front();
+            auto completion = m_Overlaps.front();
             m_Overlaps.pop();
             lock.unlock();
 
-            overlap->Complete(res);
+            if (completion.m_Error == 0)
+            {
+                completion.m_Overlap->Complete(completion.m_Bytes);
+            }
+            else
+            {
+                completion.m_Overlap->Failed(completion.m_Error);
+            }
 
             return true;
         }
 
-        void QueueInterruptSignal() noexcept
+        void RequestStop() noexcept
         {
-            auto lock = std::unique_lock{ m_Mutex };
             m_DispatchCancel.request_stop();
             m_Cond.notify_all();
+            m_FileCond.notify_all();
         }
 
         void QueueCompletion(IOCompletionOverlapped* overlap, size_t result) noexcept
         {
             auto lock = std::unique_lock{ m_Mutex };
-            m_Overlaps.emplace(overlap, result);
+            m_Overlaps.emplace(Completion
+            {
+                .m_Overlap = overlap,
+                .m_Bytes = result,
+                .m_Error = 0
+            });
             m_Cond.notify_one();
         }
 
         void QueueFailure(IOCompletionOverlapped* overlap, int32 err) noexcept
         {
             auto lock = std::unique_lock{ m_Mutex };
-            m_Overlaps.emplace(overlap, static_cast<size_t>(err));
+            m_Overlaps.emplace(Completion
+            {
+                .m_Overlap = overlap,
+                .m_Bytes = 0,
+                .m_Error = err
+            });
             m_Cond.notify_one();
+        }
+
+        bool QueueFileRead(int fd, std::span<uint8> outBytes, IOCompletionOverlapped* overlap) noexcept
+        {
+            return QueueFileRequest(FileRequest
+            {
+                .m_Operation = FileOperation::Read,
+                .m_Fd = fd,
+                .m_ReadData = outBytes.data(),
+                .m_Size = outBytes.size_bytes(),
+                .m_Overlap = overlap
+            });
+        }
+
+        bool QueueFileWrite(int fd, std::span<const uint8> inBytes, IOCompletionOverlapped* overlap) noexcept
+        {
+            return QueueFileRequest(FileRequest
+            {
+                .m_Operation = FileOperation::Write,
+                .m_Fd = fd,
+                .m_WriteData = inBytes.data(),
+                .m_Size = inBytes.size_bytes(),
+                .m_Overlap = overlap
+            });
+        }
+
+    private:
+        bool QueueFileRequest(FileRequest request) noexcept
+        {
+            if (m_DispatchCancel.stop_requested())
+            {
+                return false;
+            }
+
+            auto lock = std::unique_lock{ m_FileMutex };
+            m_FileRequests.emplace(request);
+            lock.unlock();
+            m_FileCond.notify_one();
+            return true;
+        }
+
+        void FileWorker(std::stop_token cancellationToken) noexcept
+        {
+            while (true)
+            {
+                auto lock = std::unique_lock{ m_FileMutex };
+                m_FileCond.wait(lock, [this, &cancellationToken]()
+                {
+                    return !m_FileRequests.empty() || cancellationToken.stop_requested();
+                });
+
+                if (m_FileRequests.empty())
+                {
+                    if (cancellationToken.stop_requested())
+                    {
+                        break;
+                    }
+                    continue;
+                }
+
+                FileRequest request = m_FileRequests.front();
+                m_FileRequests.pop();
+                lock.unlock();
+
+                ssize_t result = request.m_Operation == FileOperation::Read
+                    ? read(request.m_Fd, request.m_ReadData, request.m_Size)
+                    : write(request.m_Fd, request.m_WriteData, request.m_Size);
+
+                if (result >= 0)
+                {
+                    QueueCompletion(request.m_Overlap, static_cast<size_t>(result));
+                }
+                else
+                {
+                    QueueFailure(request.m_Overlap, errno);
+                }
+            }
         }
     };
 
@@ -170,8 +307,9 @@ namespace Ayla
 
     void OSXPlatformIO::QueueInterruptSignal(void* handle, int32 size) noexcept
     {
+        (void)size;
         auto iocp = reinterpret_cast<IOCompletionPort*>(handle);
-        iocp->QueueInterruptSignal();
+        iocp->RequestStop();
     }
 
     void OSXPlatformIO::OpenFileHandle(void*& Handle, String InFilename, FileMode InFileMode, FileAccessMode InAccessMode, FileSharedMode InSharedMode) noexcept
@@ -250,10 +388,12 @@ namespace Ayla
         return static_cast<int64>(st.st_size);
     }
 
-    Action<IOCompletionOverlapped*, size_t, int32> OSXPlatformIO::FileIOWrittenAction(TaskCompletionSource<size_t> TCS, void* WriteIO) noexcept
+    MoveOnlyFunction<void(IOCompletionOverlapped*, size_t, int32)> OSXPlatformIO::FileIOWrittenAction(TaskCompletionSource<size_t> TCS, void* WriteIO) noexcept
     {
         return [TCS, WriteIO](IOCompletionOverlapped* self, size_t written, int32 err)
         {
+            (void)self;
+            (void)WriteIO;
             if (err)
             {
                 TCS.TrySetException<SystemException>(err);
@@ -268,25 +408,15 @@ namespace Ayla
     bool OSXPlatformIO::WriteFile(void* handle, std::span<const uint8> inBytes, IOCompletionOverlapped* overlap) noexcept
     {
         auto* socketHandle = reinterpret_cast<SocketHandle*>(handle);
-        std::thread([socketHandle, inBytes, overlap]()
-        {
-            ssize_t written = write(socketHandle->m_fd, inBytes.data(), inBytes.size_bytes());
-            if (written >= 0)
-            {
-                overlap->Complete(static_cast<size_t>(written));
-            }
-            else
-            {
-                overlap->Failed(errno);
-            }
-        }).detach();
-        return true;
+        return socketHandle->m_CompletionPort->QueueFileWrite(socketHandle->m_fd, inBytes, overlap);
     }
 
-    Action<IOCompletionOverlapped*, size_t, int32> OSXPlatformIO::FileIOReadAction(TaskCompletionSource<size_t> TCS, void* ReadIO) noexcept
+    MoveOnlyFunction<void(IOCompletionOverlapped*, size_t, int32)> OSXPlatformIO::FileIOReadAction(TaskCompletionSource<size_t> TCS, void* ReadIO) noexcept
     {
         return [TCS, ReadIO](IOCompletionOverlapped* self, size_t read, int32 err)
         {
+            (void)self;
+            (void)ReadIO;
             if (err)
             {
                 TCS.TrySetException<SystemException>(err);
@@ -301,19 +431,7 @@ namespace Ayla
     bool OSXPlatformIO::ReadFile(void* handle, std::span<uint8> outBytes, IOCompletionOverlapped* overlap) noexcept
     {
         auto* socketHandle = reinterpret_cast<SocketHandle*>(handle);
-        std::thread([socketHandle, outBytes, overlap]()
-        {
-            ssize_t bytesRead = read(socketHandle->m_fd, outBytes.data(), outBytes.size_bytes());
-            if (bytesRead >= 0)
-            {
-                overlap->Complete(static_cast<size_t>(bytesRead));
-            }
-            else
-            {
-                overlap->Failed(errno);
-            }
-        }).detach();
-        return true;
+        return socketHandle->m_CompletionPort->QueueFileRead(socketHandle->m_fd, outBytes, overlap);
     }
 }
 

--- a/Engine/Source/Runtime/Core/Private/Platform/OSX/OSXPlatformIO.cpp
+++ b/Engine/Source/Runtime/Core/Private/Platform/OSX/OSXPlatformIO.cpp
@@ -324,14 +324,22 @@ namespace Ayla
         case FileMode::Truncate:  flags |= O_TRUNC; break;
         }
 
-        switch (InAccessMode)
+        const uint32 accessMode = (uint32)InAccessMode;
+        if (accessMode == (uint32)FileAccessMode::Read)
         {
-        case FileAccessMode::Read:    flags |= O_RDONLY; break;
-        case FileAccessMode::Write:   flags |= O_WRONLY; break;
-        case FileAccessMode::Append:  flags |= O_APPEND | O_CREAT; break;
-        case (FileAccessMode)((uint32)FileAccessMode::Read | (uint32)FileAccessMode::Write):
+            flags |= O_RDONLY;
+        }
+        else if (accessMode == (uint32)FileAccessMode::Write)
+        {
+            flags |= O_WRONLY;
+        }
+        else if (accessMode == (uint32)FileAccessMode::Append)
+        {
+            flags |= O_APPEND | O_CREAT;
+        }
+        else if (accessMode == ((uint32)FileAccessMode::Read | (uint32)FileAccessMode::Write) || accessMode == (uint32)FileAccessMode::All)
+        {
             flags |= O_RDWR;
-            break;
         }
 
         int fd = open(InFilename.AsCodepage().c_str(), flags, 0666);

--- a/Engine/Source/Runtime/Core/Private/Platform/Unix/UnixStandardStreamTextWriter.h
+++ b/Engine/Source/Runtime/Core/Private/Platform/Unix/UnixStandardStreamTextWriter.h
@@ -6,6 +6,7 @@
 
 #include "Platform/PlatformCommon.h"
 #include "IO/TextWriter.h"
+#include <cerrno>
 #include <unistd.h>
 
 namespace Ayla
@@ -24,7 +25,29 @@ namespace Ayla
 		virtual void Write(String value) override
 		{
 			auto ws = value.AsCodepage();
-			write(m_SD, ws.c_str(), ws.length());
+			const char* cursor = ws.c_str();
+			size_t remaining = ws.length();
+			while (remaining > 0)
+			{
+				ssize_t written = write(m_SD, cursor, remaining);
+				if (written < 0)
+				{
+					if (errno == EINTR)
+					{
+						continue;
+					}
+
+					break;
+				}
+
+				if (written == 0)
+				{
+					break;
+				}
+
+				cursor += written;
+				remaining -= (size_t)written;
+			}
 		}
 
 		int32 GetNativeHandle() const { return m_SD; }

--- a/Engine/Source/Runtime/Core/Public/AggregateException.h
+++ b/Engine/Source/Runtime/Core/Public/AggregateException.h
@@ -10,10 +10,22 @@ namespace Ayla
 	{
 		const std::vector<std::exception_ptr> m_InnerExceptions;
 
+	private:
+		template<std::ranges::input_range IR>
+		static std::vector<std::exception_ptr> ToVector(IR&& exceptions)
+		{
+			std::vector<std::exception_ptr> result;
+			for (auto&& exception : exceptions)
+			{
+				result.emplace_back(std::forward<decltype(exception)>(exception));
+			}
+			return result;
+		}
+
 	public:
 		template<std::ranges::input_range IR>
 		AggregateException(IR&& exceptions) requires std::convertible_to<std::ranges::range_value_t<IR>, std::exception_ptr>
-			: m_InnerExceptions(std::ranges::to<std::vector>(std::forward<IR>(exceptions)))
+			: m_InnerExceptions(ToVector(std::forward<IR>(exceptions)))
 		{
 		}
 

--- a/Engine/Source/Runtime/Core/Public/Object.h
+++ b/Engine/Source/Runtime/Core/Public/Object.h
@@ -89,13 +89,20 @@ namespace Ayla
 		void* BindGCHandle__Unsafe(ssize_t gcHandlePtr);
 		ObjectReferenceWrapper AsWrapper();
 		
-		template<class T>
-		auto AsShared(this T&& self)
+		template<std::derived_from<Object> T = Object>
+		auto AsShared()
 		{
-			using U = std::remove_const_t<std::remove_reference_t<T>>;
-			auto& hack = const_cast<U&>(self);
-			hack.AddRef();
-			return SharedPtr<U>(&hack);
+			auto* self = static_cast<T*>(this);
+			self->AddRef();
+			return SharedPtr<T>(self);
+		}
+
+		template<std::derived_from<Object> T = Object>
+		auto AsShared() const
+		{
+			auto* self = const_cast<T*>(static_cast<const T*>(this));
+			self->AddRef();
+			return SharedPtr<T>(self);
 		}
 
 		Object& operator =(const Object&) = delete;
@@ -108,7 +115,7 @@ namespace Ayla
 			std::optional<SharedPtr<T>> ptr;
 			ConfigureNew(typeid(T), CreationFlags::None, [&]()
 			{
-				ptr.emplace((new T(std::forward<TArgs>(args)...))->AsShared());
+				ptr.emplace((new T(std::forward<TArgs>(args)...))->template AsShared<T>());
 			});
 			return std::move(ptr).value();
 		}

--- a/Engine/Source/Runtime/Core/Public/Platform/Linux/LinuxPlatformIO.h
+++ b/Engine/Source/Runtime/Core/Public/Platform/Linux/LinuxPlatformIO.h
@@ -15,6 +15,7 @@
 #include "IO/FileSharedMode.h"
 #include "IO/SeekOrigin.h"
 #include "Threading/Tasks/TaskCompletionSource.h"
+#include "MoveOnlyFunction.h"
 
 namespace Ayla
 {
@@ -42,10 +43,10 @@ namespace Ayla
 		static bool SetFileSeekPointer(void* Handle, int64 Seekpos, SeekOrigin InOrigin) noexcept;
 		static int64 GetFileSize(void* Handle) noexcept;
 
-		static Action<IOCompletionOverlapped*, size_t, int32> FileIOWrittenAction(TaskCompletionSource<size_t> TCS, void* WriteIO) noexcept;
+		static MoveOnlyFunction<void(IOCompletionOverlapped*, size_t, int32)> FileIOWrittenAction(TaskCompletionSource<size_t> TCS, void* WriteIO) noexcept;
 		static bool WriteFile(void* Handle, std::span<const uint8> InBytes, IOCompletionOverlapped* Overlap) noexcept;
 
-		static Action<IOCompletionOverlapped*, size_t, int32> FileIOReadAction(TaskCompletionSource<size_t> TCS, void* ReadIO) noexcept;
+		static MoveOnlyFunction<void(IOCompletionOverlapped*, size_t, int32)> FileIOReadAction(TaskCompletionSource<size_t> TCS, void* ReadIO) noexcept;
 		static bool ReadFile(void* Handle, std::span<uint8> OutBytes, IOCompletionOverlapped* Overlap) noexcept;
 	};
 

--- a/Engine/Source/Runtime/Core/Public/Platform/OSX/OSXPlatformIO.h
+++ b/Engine/Source/Runtime/Core/Public/Platform/OSX/OSXPlatformIO.h
@@ -15,6 +15,7 @@
 #include "IO/FileSharedMode.h"
 #include "IO/SeekOrigin.h"
 #include "Threading/Tasks/TaskCompletionSource.h"
+#include "MoveOnlyFunction.h"
 
 namespace Ayla
 {
@@ -42,10 +43,10 @@ namespace Ayla
 		static bool SetFileSeekPointer(void* Handle, int64 Seekpos, SeekOrigin InOrigin) noexcept;
 		static int64 GetFileSize(void* Handle) noexcept;
 
-		static Action<IOCompletionOverlapped*, size_t, int32> FileIOWrittenAction(TaskCompletionSource<size_t> TCS, void* WriteIO) noexcept;
+		static MoveOnlyFunction<void(IOCompletionOverlapped*, size_t, int32)> FileIOWrittenAction(TaskCompletionSource<size_t> TCS, void* WriteIO) noexcept;
 		static bool WriteFile(void* Handle, std::span<const uint8> InBytes, IOCompletionOverlapped* Overlap) noexcept;
 
-		static Action<IOCompletionOverlapped*, size_t, int32> FileIOReadAction(TaskCompletionSource<size_t> TCS, void* ReadIO) noexcept;
+		static MoveOnlyFunction<void(IOCompletionOverlapped*, size_t, int32)> FileIOReadAction(TaskCompletionSource<size_t> TCS, void* ReadIO) noexcept;
 		static bool ReadFile(void* Handle, std::span<uint8> OutBytes, IOCompletionOverlapped* Overlap) noexcept;
 	};
 

--- a/Engine/Source/Runtime/Core/Public/SharedPtr.h
+++ b/Engine/Source/Runtime/Core/Public/SharedPtr.h
@@ -160,14 +160,14 @@ namespace Ayla
 			return dynamic_cast<U*>(m_Ptr) != nullptr;
 		}
 
-		template<class S>
-		constexpr auto Get(this S&& self) noexcept { return const_cast<T*>(self.m_Ptr); }
+		constexpr T* Get() noexcept { return m_Ptr; }
+		constexpr T* Get() const noexcept { return m_Ptr; }
 
 		constexpr operator bool() const noexcept { return m_Ptr; }
 		constexpr auto operator <=>(const SharedPtr& other) const noexcept { return m_Ptr <=> other.m_Ptr; }
 
-		template<class S>
-		constexpr auto operator ->(this S&& self) noexcept { return const_cast<T*>(self.m_Ptr); }
+		constexpr T* operator ->() noexcept { return Get(); }
+		constexpr T* operator ->() const noexcept { return Get(); }
 
 		inline SharedPtr& operator =(const SharedPtr& other) noexcept
 		{

--- a/Engine/Source/Runtime/Core/Public/Threading/Tasks/PromiseType.h
+++ b/Engine/Source/Runtime/Core/Public/Threading/Tasks/PromiseType.h
@@ -20,10 +20,9 @@ namespace Ayla
 			m_Task = std::make_shared<SharedTask<T>>();
 		}
 
-		template<class C>
-		SharedTask<T>* GetTask(this C&& c) noexcept
+		SharedTask<T>* GetTask() noexcept
 		{
-			return c.m_Task.get();
+			return m_Task.get();
 		}
 
 	public:

--- a/Engine/Source/Runtime/Core/Public/Threading/Tasks/Task.h
+++ b/Engine/Source/Runtime/Core/Public/Threading/Tasks/Task.h
@@ -380,7 +380,11 @@ namespace Ayla
 		{
 			static_assert(std::same_as<T, void>, "Use Task<>::WhenAll instead.");
 
-			auto v = std::ranges::to<std::vector>(std::forward<IR>(tasks));
+			std::vector<std::ranges::range_value_t<IR>> v;
+			for (auto&& task : tasks)
+			{
+				v.emplace_back(std::forward<decltype(task)>(task));
+			}
 			return WhenAll(std::move(v));
 		}
 
@@ -458,7 +462,11 @@ namespace Ayla
 		{
 			static_assert(std::same_as<T, void>, "Use Task<>::WhenAny instead.");
 
-			auto v = std::ranges::to<std::vector>(std::forward<IR>(tasks));
+			std::vector<std::ranges::range_value_t<IR>> v;
+			for (auto&& task : tasks)
+			{
+				v.emplace_back(std::forward<decltype(task)>(task));
+			}
 			return WhenAny(std::move(v));
 		}
 
@@ -488,7 +496,7 @@ namespace Ayla
 			return WhenAny(std::move(taskVector));
 		}
 
-		// Unwrap for Task<Task<T>> ¡æ Task<T>
+		// Unwrap for Task<Task<T>> to Task<T>
 		template<class U = T>
 		auto Unwrap() const -> Task<typename U::ValueType>
 			requires std::same_as<U, Task<typename U::ValueType>>

--- a/Engine/Source/Runtime/Direct3D12/Private/D3D12Shader.cpp
+++ b/Engine/Source/Runtime/Direct3D12/Private/D3D12Shader.cpp
@@ -16,7 +16,7 @@ namespace Ayla
 
 	VertexFactory* D3D12Shader::GetVertexFactory() const
 	{
-		return m_CreationInfo.VertexFactory.get();
+		return m_CreationInfo.m_VertexFactory.get();
 	}
 
 	bool D3D12Shader::Has(ShaderType type) const
@@ -24,25 +24,25 @@ namespace Ayla
 		switch (type)
 		{
 		case ShaderType::Vertex:
-			return !m_CreationInfo.VertexShader.Bytecode.empty();
+			return !m_CreationInfo.m_VertexShader.Bytecode.empty();
 		case ShaderType::Pixel:
-			return !m_CreationInfo.FragmentShader.Bytecode.empty();
+			return !m_CreationInfo.m_FragmentShader.Bytecode.empty();
 		case ShaderType::Domain:
-			return !m_CreationInfo.DomainShader.Bytecode.empty();
+			return !m_CreationInfo.m_DomainShader.Bytecode.empty();
 		case ShaderType::Hull:
-			return !m_CreationInfo.HullShader.Bytecode.empty();
+			return !m_CreationInfo.m_HullShader.Bytecode.empty();
 		case ShaderType::Geometry:
-			return !m_CreationInfo.GeometryShader.Bytecode.empty();
+			return !m_CreationInfo.m_GeometryShader.Bytecode.empty();
 		case ShaderType::Compute:
-			return !m_CreationInfo.ComputeShader.Bytecode.empty();
+			return !m_CreationInfo.m_ComputeShader.Bytecode.empty();
 		case ShaderType::RayGeneration:
-			return !m_CreationInfo.RayGenerationShader.Bytecode.empty();
+			return !m_CreationInfo.m_RayGenerationShader.Bytecode.empty();
 		case ShaderType::ClosestHit:
-			return !m_CreationInfo.ClosestHitShader.Bytecode.empty();
+			return !m_CreationInfo.m_ClosestHitShader.Bytecode.empty();
 		case ShaderType::AnyHit:
-			return !m_CreationInfo.AnyHitShader.Bytecode.empty();
+			return !m_CreationInfo.m_AnyHitShader.Bytecode.empty();
 		case ShaderType::Miss:
-			return !m_CreationInfo.MissShader.Bytecode.empty();
+			return !m_CreationInfo.m_MissShader.Bytecode.empty();
 		default:
 			return false;
 		}
@@ -53,25 +53,25 @@ namespace Ayla
 		switch (type)
 		{
 		case ShaderType::Vertex:
-			return m_CreationInfo.VertexShader;
+			return m_CreationInfo.m_VertexShader;
 		case ShaderType::Pixel:
-			return m_CreationInfo.FragmentShader;
+			return m_CreationInfo.m_FragmentShader;
 		case ShaderType::Domain:
-			return m_CreationInfo.DomainShader;
+			return m_CreationInfo.m_DomainShader;
 		case ShaderType::Hull:
-			return m_CreationInfo.HullShader;
+			return m_CreationInfo.m_HullShader;
 		case ShaderType::Geometry:
-			return m_CreationInfo.GeometryShader;
+			return m_CreationInfo.m_GeometryShader;
 		case ShaderType::Compute:
-			return m_CreationInfo.ComputeShader;
+			return m_CreationInfo.m_ComputeShader;
 		case ShaderType::RayGeneration:
-			return m_CreationInfo.RayGenerationShader;
+			return m_CreationInfo.m_RayGenerationShader;
 		case ShaderType::ClosestHit:
-			return m_CreationInfo.ClosestHitShader;
+			return m_CreationInfo.m_ClosestHitShader;
 		case ShaderType::AnyHit:
-			return m_CreationInfo.AnyHitShader;
+			return m_CreationInfo.m_AnyHitShader;
 		case ShaderType::Miss:
-			return m_CreationInfo.MissShader;
+			return m_CreationInfo.m_MissShader;
 		default:
 			throw InvalidOperationException(TEXT("Invalid shader type."));
 		}

--- a/Engine/Source/Runtime/Engine/Private/Engine.cpp
+++ b/Engine/Source/Runtime/Engine/Private/Engine.cpp
@@ -58,19 +58,19 @@ namespace Ayla
 		tasks.emplace_back(Task<>::Create([this, &applicationDirectory]() -> Task<>
 		{
 			ShaderCreationInfo sci = {};
-			sci.VertexFactory = std::make_shared<PositionColorVertexFactory>();
+			sci.m_VertexFactory = std::make_shared<PositionColorVertexFactory>();
 			std::vector<Task<>> tasks;
 			tasks.emplace_back(File::ReadAllBytesAsync(applicationDirectory.GetFile(TEXT("Shaders/DefaultVertex.cso"))).ContinueWith([&](auto r)
 			{
 				auto& bytecode = r.GetResult();
-				sci.VertexShader.Bytecode = std::move(bytecode);
-				sci.VertexShader.EntrypointName = TEXT("main");
+				sci.m_VertexShader.Bytecode = std::move(bytecode);
+				sci.m_VertexShader.EntrypointName = TEXT("main");
 			}));
 			tasks.emplace_back(File::ReadAllBytesAsync(applicationDirectory.GetFile(TEXT("Shaders/DefaultPixel.cso"))).ContinueWith([&](auto r)
 			{
 				auto& bytecode = r.GetResult();
-				sci.FragmentShader.Bytecode = std::move(bytecode);
-				sci.FragmentShader.EntrypointName = TEXT("main");
+				sci.m_FragmentShader.Bytecode = std::move(bytecode);
+				sci.m_FragmentShader.EntrypointName = TEXT("main");
 			}));
 
 			co_await Task<>::WhenAll(tasks);
@@ -84,20 +84,20 @@ namespace Ayla
 			tasks.emplace_back(File::ReadAllBytesAsync(applicationDirectory.GetFile(TEXT("Shaders/DefaultRayGeneration.cso"))).ContinueWith([&](auto r)
 			{
 				auto& bytecode = r.GetResult();
-				sci.RayGenerationShader.Bytecode = std::move(bytecode);
-				sci.RayGenerationShader.EntrypointName = TEXT("DefaultRayGeneration");
+				sci.m_RayGenerationShader.Bytecode = std::move(bytecode);
+				sci.m_RayGenerationShader.EntrypointName = TEXT("DefaultRayGeneration");
 			}));
 			tasks.emplace_back(File::ReadAllBytesAsync(applicationDirectory.GetFile(TEXT("Shaders/DefaultHit.cso"))).ContinueWith([&](auto r)
 			{
 				auto& bytecode = r.GetResult();
-				sci.ClosestHitShader.Bytecode = std::move(bytecode);
-				sci.ClosestHitShader.EntrypointName = TEXT("DefaultClosestHit");
+				sci.m_ClosestHitShader.Bytecode = std::move(bytecode);
+				sci.m_ClosestHitShader.EntrypointName = TEXT("DefaultClosestHit");
 			}));
 			tasks.emplace_back(File::ReadAllBytesAsync(applicationDirectory.GetFile(TEXT("Shaders/DefaultMiss.cso"))).ContinueWith([&](auto r)
 			{
 				auto& bytecode = r.GetResult();
-				sci.MissShader.Bytecode = std::move(bytecode);
-				sci.MissShader.EntrypointName = TEXT("DefaultMiss");
+				sci.m_MissShader.Bytecode = std::move(bytecode);
+				sci.m_MissShader.EntrypointName = TEXT("DefaultMiss");
 			}));
 
 			co_await Task<>::WhenAll(tasks);

--- a/Engine/Source/Runtime/Engine/Private/GameInstance.cpp
+++ b/Engine/Source/Runtime/Engine/Private/GameInstance.cpp
@@ -68,7 +68,7 @@ namespace Ayla
 
 	SharedPtr<Engine> GameInstance::GetEngine()
 	{
-		return m_Engine->AsShared();
+		return m_Engine->AsShared<Engine>();
 	}
 
 	SharedPtr<Scene> GameInstance::GetEntryScene_Implementation()

--- a/Engine/Source/Runtime/Engine/Private/Rendering/RenderThread.cpp
+++ b/Engine/Source/Runtime/Engine/Private/Rendering/RenderThread.cpp
@@ -14,7 +14,7 @@ namespace Ayla
 		m_Current = this;
 	}
 
-	RenderThread::~RenderThread()
+	RenderThread::~RenderThread() noexcept
 	{
 	}
 

--- a/Engine/Source/Runtime/Numerics/Public/Numerics/DirectXMath.h
+++ b/Engine/Source/Runtime/Numerics/Public/Numerics/DirectXMath.h
@@ -225,6 +225,44 @@
 
 namespace DirectX
 {
+#if (__cplusplus >= 202002L)
+    namespace Internal
+    {
+        template<size_t RowCount, size_t ColumnCount>
+        constexpr bool MatrixEquals(const float(&left)[RowCount][ColumnCount], const float(&right)[RowCount][ColumnCount]) noexcept
+        {
+            for (size_t row = 0; row < RowCount; ++row)
+            {
+                for (size_t column = 0; column < ColumnCount; ++column)
+                {
+                    if (left[row][column] != right[row][column])
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        template<size_t RowCount, size_t ColumnCount>
+        constexpr std::partial_ordering MatrixCompare(const float(&left)[RowCount][ColumnCount], const float(&right)[RowCount][ColumnCount]) noexcept
+        {
+            for (size_t row = 0; row < RowCount; ++row)
+            {
+                for (size_t column = 0; column < ColumnCount; ++column)
+                {
+                    if (auto order = left[row][column] <=> right[row][column]; order != 0)
+                    {
+                        return order;
+                    }
+                }
+            }
+
+            return std::partial_ordering::equivalent;
+        }
+    }
+#endif
 
     /****************************************************************************
      *
@@ -854,8 +892,8 @@ namespace DirectX
         float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
 
 #if (__cplusplus >= 202002L)
-        bool operator == (const XMFLOAT3X3&) const = default;
-        auto operator <=> (const XMFLOAT3X3&) const = default;
+        constexpr bool operator == (const XMFLOAT3X3& other) const noexcept { return Internal::MatrixEquals(m, other.m); }
+        constexpr std::partial_ordering operator <=> (const XMFLOAT3X3& other) const noexcept { return Internal::MatrixCompare(m, other.m); }
 #endif
     };
 
@@ -898,8 +936,8 @@ namespace DirectX
         float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
 
 #if (__cplusplus >= 202002L)
-        bool operator == (const XMFLOAT4X3&) const = default;
-        auto operator <=> (const XMFLOAT4X3&) const = default;
+        constexpr bool operator == (const XMFLOAT4X3& other) const noexcept { return Internal::MatrixEquals(m, other.m); }
+        constexpr std::partial_ordering operator <=> (const XMFLOAT4X3& other) const noexcept { return Internal::MatrixCompare(m, other.m); }
 #endif
     };
 
@@ -945,8 +983,8 @@ namespace DirectX
         float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
 
 #if (__cplusplus >= 202002L)
-        bool operator == (const XMFLOAT3X4&) const = default;
-        auto operator <=> (const XMFLOAT3X4&) const = default;
+        constexpr bool operator == (const XMFLOAT3X4& other) const noexcept { return Internal::MatrixEquals(m, other.m); }
+        constexpr std::partial_ordering operator <=> (const XMFLOAT3X4& other) const noexcept { return Internal::MatrixCompare(m, other.m); }
 #endif
     };
 
@@ -994,8 +1032,8 @@ namespace DirectX
         float& operator() (size_t Row, size_t Column) noexcept { return m[Row][Column]; }
 
 #if (__cplusplus >= 202002L)
-        bool operator == (const XMFLOAT4X4&) const = default;
-        auto operator <=> (const XMFLOAT4X4&) const = default;
+        constexpr bool operator == (const XMFLOAT4X4& other) const noexcept { return Internal::MatrixEquals(m, other.m); }
+        constexpr std::partial_ordering operator <=> (const XMFLOAT4X4& other) const noexcept { return Internal::MatrixCompare(m, other.m); }
 #endif
     };
 
@@ -2277,4 +2315,3 @@ namespace DirectX
 #endif
 
 } // namespace DirectX
-

--- a/Engine/Source/Runtime/Numerics/Public/Numerics/MatrixInterface/Matrix4x4.h
+++ b/Engine/Source/Runtime/Numerics/Public/Numerics/MatrixInterface/Matrix4x4.h
@@ -655,21 +655,21 @@ namespace Ayla
 
 	template<class T>
 	template<TIsMatrix<T, 4, 4> IMatrix, TIsVector<T, 3> IPoint>
-	static IPoint Matrix4x4<T>::TransformPoint(const IMatrix& M, const IPoint& P)
+	IPoint Matrix4x4<T>::TransformPoint(const IMatrix& M, const IPoint& P)
 	{
 		return Matrix4x4<>::TransformPoint(Matrix4x4<T>(M), Vector3<T>(P));
 	}
 
 	template<class T>
 	template<TIsVector<T, 3> ILocation, TIsVector<T, 3> IDir, TIsVector<T, 3> IUp>
-	static Matrix4x4<T> Matrix4x4<T>::LookToLH(const ILocation& Location, const IDir& Dir, const IUp& Up)
+	Matrix4x4<T> Matrix4x4<T>::LookToLH(const ILocation& Location, const IDir& Dir, const IUp& Up)
 	{
 		return LookToLH(Vector3<T>(Location), Vector3<T>(Dir), Vector3<T>(Up));
 	}
 
 	template<class T>
 	template<TIsMatrix<T, 4, 3> IMatrix, TIsVector<T, 3> ITranslation, TIsVector<T, 3> IScale, TIsVector<T, 4> IQuaternion>
-	static auto Matrix4x4<T>::AffineTransformation(const ITranslation& translate, const IScale& scale, const IQuaternion& rot)
+	auto Matrix4x4<T>::AffineTransformation(const ITranslation& translate, const IScale& scale, const IQuaternion& rot)
 	{
 		Matrix4x4 M = Matrix4x4<>::AffineTransformation(Translate3D<T>(translate), Scale3D<T>(scale), Quaternion<T>(rot));
 		IMatrix R = IMatrix::Identity();

--- a/Engine/Source/Runtime/Numerics/Public/Numerics/MatrixInterface/Matrix4x4.h
+++ b/Engine/Source/Runtime/Numerics/Public/Numerics/MatrixInterface/Matrix4x4.h
@@ -246,168 +246,185 @@ namespace Ayla
 #define MX_C(v) reinterpret_cast<const Matrix4x4<T>&>(v)
 #define MX_V(v) reinterpret_cast<Matrix4x4<T>&>(v)
 
-#define ASSIGN(x, y) x = reinterpret_cast<std::remove_reference_t<decltype(x)>&>(y)
 #define FLOAT3(x) DirectX::XMLoadFloat3(reinterpret_cast<const DirectX::XMFLOAT3*>(&x))
 #define FLOAT4(x) reinterpret_cast<const DirectX::XMVECTOR&>(x)
 
 		template<class T>
 		static constexpr T Determinant(const Matrix4x4<T>& M)
 		{
-			if constexpr (std::same_as<T, float> && std::is_constant_evaluated() == false)
+			if constexpr (std::same_as<T, float>)
 			{
-				using namespace DirectX;
-				auto v = XMMatrixDeterminant(XM_C(M));
-				return XMVectorGetX(v);
+				if (!std::is_constant_evaluated())
+				{
+					using namespace DirectX;
+					auto v = XMMatrixDeterminant(XM_C(M));
+					return XMVectorGetX(v);
+				}
 			}
-			else
-			{
-				return
-					M[0][0] * (M[1][1] * (M[2][2] * M[3][3] - M[2][3] * M[3][2]) -
-						M[1][2] * (M[2][1] * M[3][3] - M[2][3] * M[3][1]) +
-						M[1][3] * (M[2][1] * M[3][2] - M[2][2] * M[3][1])) -
-					M[0][1] * (M[1][0] * (M[2][2] * M[3][3] - M[2][3] * M[3][2]) -
-						M[1][2] * (M[2][0] * M[3][3] - M[2][3] * M[3][0]) +
-						M[1][3] * (M[2][0] * M[3][2] - M[2][2] * M[3][0])) +
-					M[0][2] * (M[1][0] * (M[2][1] * M[3][3] - M[2][3] * M[3][1]) -
-						M[1][1] * (M[2][0] * M[3][3] - M[2][3] * M[3][0]) +
-						M[1][3] * (M[2][0] * M[3][1] - M[2][1] * M[3][0])) -
-					M[0][3] * (M[1][0] * (M[2][1] * M[3][2] - M[2][2] * M[3][1]) -
-						M[1][1] * (M[2][0] * M[3][2] - M[2][2] * M[3][0]) +
-						M[1][2] * (M[2][0] * M[3][1] - M[2][1] * M[3][0]));
-			}
+
+			return
+				M[0][0] * (M[1][1] * (M[2][2] * M[3][3] - M[2][3] * M[3][2]) -
+					M[1][2] * (M[2][1] * M[3][3] - M[2][3] * M[3][1]) +
+					M[1][3] * (M[2][1] * M[3][2] - M[2][2] * M[3][1])) -
+				M[0][1] * (M[1][0] * (M[2][2] * M[3][3] - M[2][3] * M[3][2]) -
+					M[1][2] * (M[2][0] * M[3][3] - M[2][3] * M[3][0]) +
+					M[1][3] * (M[2][0] * M[3][2] - M[2][2] * M[3][0])) +
+				M[0][2] * (M[1][0] * (M[2][1] * M[3][3] - M[2][3] * M[3][1]) -
+					M[1][1] * (M[2][0] * M[3][3] - M[2][3] * M[3][0]) +
+					M[1][3] * (M[2][0] * M[3][1] - M[2][1] * M[3][0])) -
+				M[0][3] * (M[1][0] * (M[2][1] * M[3][2] - M[2][2] * M[3][1]) -
+					M[1][1] * (M[2][0] * M[3][2] - M[2][2] * M[3][0]) +
+					M[1][2] * (M[2][0] * M[3][1] - M[2][1] * M[3][0]));
 		}
 
 		template<class T>
 		static constexpr Matrix4x4<T> Inverse(const Matrix4x4<T>& M)
 		{
-			if constexpr (std::same_as<T, float> && std::is_constant_evaluated() == false)
+			if constexpr (std::same_as<T, float>)
 			{
-				using namespace DirectX;
-				return MX_V(XMMatrixInverse(nullptr, XM_V(M)));
+				if (!std::is_constant_evaluated())
+				{
+					using namespace DirectX;
+					Matrix4x4<T> result;
+					XMStoreFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&result), XMMatrixInverse(nullptr, XM_C(M)));
+					return result;
+				}
 			}
-			else
-			{
-				return Matrix<>::Inverse(M);
-			}
+
+			return Matrix<>::Inverse(M);
 		}
 
 		template<class T>
 		static constexpr bool Decompose(const Matrix4x4<T>& M, Translate3D<T>& translate, Scale3D<T>& scale, Quaternion<T>& rotation)
 		{
-			if constexpr (std::same_as<T, float> && std::is_constant_evaluated() == false)
+			if constexpr (std::same_as<T, float>)
 			{
-				using namespace DirectX;
-				XMVECTOR xmtrans, xmscale, xmquat;
-				bool success = XMMatrixDecompose(&xmtrans, &xmscale, &xmquat, XM_C(M));
-				ASSIGN(translate, xmtrans);
-				ASSIGN(scale, xmscale);
-				ASSIGN(rotation, xmquat);
-				return success;
+				if (!std::is_constant_evaluated())
+				{
+					using namespace DirectX;
+					XMVECTOR xmtrans, xmscale, xmquat;
+					bool success = XMMatrixDecompose(&xmtrans, &xmscale, &xmquat, XM_C(M));
+					XMStoreFloat3(reinterpret_cast<XMFLOAT3*>(&translate), xmtrans);
+					XMStoreFloat3(reinterpret_cast<XMFLOAT3*>(&scale), xmscale);
+					XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&rotation), xmquat);
+					return success;
+				}
 			}
-			else
-			{
-				// Extract Translation
-				translate = Translate3D<T>(M[0][3], M[1][3], M[2][3]);
 
-				// Extract Scale
-				scale = Scale3D<T>(
-					Math::Sqrt(M[0][0] * M[0][0] + M[0][1] * M[0][1] + M[0][2] * M[0][2]),
-					Math::Sqrt(M[1][0] * M[1][0] + M[1][1] * M[1][1] + M[1][2] * M[1][2]),
-					Math::Sqrt(M[2][0] * M[2][0] + M[2][1] * M[2][1] + M[2][2] * M[2][2])
-				);
+			// Extract Translation
+			translate = Translate3D<T>(M[0][3], M[1][3], M[2][3]);
 
-				// Normalize rotation matrix by removing scale
-				T m00 = M[0][0] / scale.X, m01 = M[0][1] / scale.X, m02 = M[0][2] / scale.X;
-				T m10 = M[1][0] / scale.Y, m11 = M[1][1] / scale.Y, m12 = M[1][2] / scale.Y;
-				T m20 = M[2][0] / scale.Z, m21 = M[2][1] / scale.Z, m22 = M[2][2] / scale.Z;
+			// Extract Scale
+			scale = Scale3D<T>(
+				Math::Sqrt(M[0][0] * M[0][0] + M[0][1] * M[0][1] + M[0][2] * M[0][2]),
+				Math::Sqrt(M[1][0] * M[1][0] + M[1][1] * M[1][1] + M[1][2] * M[1][2]),
+				Math::Sqrt(M[2][0] * M[2][0] + M[2][1] * M[2][1] + M[2][2] * M[2][2])
+			);
 
-				// Extract Rotation as Quaternion
-				T qw = Math::Sqrt(1.0 + m00 + m11 + m22) / 2.0;
-				T qx = (m21 - m12) / (4.0 * qw);
-				T qy = (m02 - m20) / (4.0 * qw);
-				T qz = (m10 - m01) / (4.0 * qw);
+			// Normalize rotation matrix by removing scale
+			T m00 = M[0][0] / scale.X, m01 = M[0][1] / scale.X, m02 = M[0][2] / scale.X;
+			T m10 = M[1][0] / scale.Y, m11 = M[1][1] / scale.Y, m12 = M[1][2] / scale.Y;
+			T m20 = M[2][0] / scale.Z, m21 = M[2][1] / scale.Z, m22 = M[2][2] / scale.Z;
 
-				rotation = Quaternion<T>(qw, qx, qy, qz);
-			}
+			// Extract Rotation as Quaternion
+			T qw = Math::Sqrt(1.0 + m00 + m11 + m22) / 2.0;
+			T qx = (m21 - m12) / (4.0 * qw);
+			T qy = (m02 - m20) / (4.0 * qw);
+			T qz = (m10 - m01) / (4.0 * qw);
+
+			rotation = Quaternion<T>(qw, qx, qy, qz);
+			return true;
 		}
 
 		template<class T>
 		static constexpr Vector3<T> TransformPoint(const Matrix4x4<T>& M, const Vector3<T>& P)
 		{
-			if constexpr (std::same_as<T, float> && std::is_constant_evaluated() == false)
+			if constexpr (std::same_as<T, float>)
 			{
-				using namespace DirectX;
-				auto r = XMVector3Transform(FLOAT3(P), XM_C(M));
-				return reinterpret_cast<Vector3<T>&>(r);
+				if (!std::is_constant_evaluated())
+				{
+					using namespace DirectX;
+					auto r = XMVector3Transform(FLOAT3(P), XM_C(M));
+					Vector3<T> result;
+					XMStoreFloat3(reinterpret_cast<XMFLOAT3*>(&result), r);
+					return result;
+				}
 			}
-			else
-			{
-				return Matrix<>::TransformPoint(M, P);
-			}
+
+			return Matrix<>::TransformPoint(M, P);
 		}
 
 		template<class T>
 		static constexpr Vector3<T> TransformVector(const Matrix4x4<T>& M, const Vector3<T>& V)
 		{
-			if constexpr (std::same_as<T, float> && std::is_constant_evaluated() == false)
+			if constexpr (std::same_as<T, float>)
 			{
-				using namespace DirectX;
-				auto r = XMVector3TransformNormal(FLOAT3(V), XM_C(M));
-				return reinterpret_cast<Vector3<T>&>(r);
+				if (!std::is_constant_evaluated())
+				{
+					using namespace DirectX;
+					auto r = XMVector3TransformNormal(FLOAT3(V), XM_C(M));
+					Vector3<T> result;
+					XMStoreFloat3(reinterpret_cast<XMFLOAT3*>(&result), r);
+					return result;
+				}
 			}
-			else
-			{
-				return Matrix<>::TransformVector(M, V);
-			}
+
+			return Matrix<>::TransformVector(M, V);
 		}
 
 		template<class T>
 		static constexpr Matrix4x4<T> Multiply(const Matrix4x4<T>& ML, const Matrix4x4<T>& MR)
 		{
-			if constexpr (std::same_as<T, float> && std::is_constant_evaluated() == false)
+			if constexpr (std::same_as<T, float>)
 			{
-				using namespace DirectX;
-				return reinterpret_cast<Matrix4x4<T>&>(XMMatrixMultiply(XM_C(ML), XM_C(MR)));
+				if (!std::is_constant_evaluated())
+				{
+					using namespace DirectX;
+					Matrix4x4<T> result;
+					XMStoreFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&result), XMMatrixMultiply(XM_C(ML), XM_C(MR)));
+					return result;
+				}
 			}
-			else
-			{
-				return Matrix<>::Multiply(ML, MR);
-			}
+
+			return Matrix<>::Multiply(ML, MR);
 		}
 
 		template<class T>
 		static constexpr Matrix4x4<T> LookToLH(const Vector3<T>& EyePosition, const Vector3<T>& EyeDirection, const Vector3<T>& UpDirection)
 		{
-			if constexpr (std::same_as<T, float> && std::is_constant_evaluated() == false)
+			if constexpr (std::same_as<T, float>)
 			{
-				using namespace DirectX;
-				auto location = FLOAT3(EyePosition);
-				auto direction = FLOAT3(EyeDirection);
-				auto up = FLOAT3(UpDirection);
-				return reinterpret_cast<Matrix4x4<T>&>(XMMatrixLookToLH(location, direction, up));
+				if (!std::is_constant_evaluated())
+				{
+					using namespace DirectX;
+					auto location = FLOAT3(EyePosition);
+					auto direction = FLOAT3(EyeDirection);
+					auto up = FLOAT3(UpDirection);
+					Matrix4x4<T> result;
+					XMStoreFloat4x4(reinterpret_cast<XMFLOAT4X4*>(&result), XMMatrixLookToLH(location, direction, up));
+					return result;
+				}
 			}
-			else
-			{
-				auto R2 = Vector<>::Normalize(EyeDirection);
-				auto R0 = Vector<>::Cross(UpDirection, R2);
-				R0 = Vector<>::Normalize(R0);
 
-				auto R1 = Vector<>::Cross(R2, R0);
+			auto R2 = Vector<>::Normalize(EyeDirection);
+			auto R0 = Vector<>::Cross(UpDirection, R2);
+			R0 = Vector<>::Normalize(R0);
 
-				auto NegEyePosition = -EyePosition;
+			auto R1 = Vector<>::Cross(R2, R0);
 
-				auto D0 = Vector<>::Dot(R0, NegEyePosition);
-				auto D1 = Vector<>::Dot(R1, NegEyePosition);
-				auto D2 = Vector<>::Dot(R2, NegEyePosition);
+			auto NegEyePosition = -EyePosition;
 
-				Matrix4x4<T> M;
-				M[0] = Vector4<T>(R0, D0);
-				M[1] = Vector4<T>(R1, D1);
-				M[2] = Vector4<T>(R2, D2);
-				M[3] = Vector4<T>(0, 0, 0, 1.0);
+			auto D0 = Vector<>::Dot(R0, NegEyePosition);
+			auto D1 = Vector<>::Dot(R1, NegEyePosition);
+			auto D2 = Vector<>::Dot(R2, NegEyePosition);
 
-				return Matrix<>::Transpose(M);
-			}
+			Matrix4x4<T> M;
+			M[0] = Vector4<T>(R0, D0);
+			M[1] = Vector4<T>(R1, D1);
+			M[2] = Vector4<T>(R2, D2);
+			M[3] = Vector4<T>(0, 0, 0, 1.0);
+
+			return Matrix<>::Transpose(M);
 		}
 
 		template<class T>

--- a/Engine/Source/Runtime/Numerics/Public/Numerics/TransformInterface/Quaternion.h
+++ b/Engine/Source/Runtime/Numerics/Public/Numerics/TransformInterface/Quaternion.h
@@ -118,57 +118,63 @@ namespace Ayla
 	public:
 		static Quaternion FromAxisAngle(const Vector3<T>& Axis, Degrees<T> Angle)
 		{
-			if constexpr (std::same_as<T, float> && std::is_constant_evaluated())
+			if constexpr (std::same_as<T, float>)
 			{
-				using namespace DirectX;
-				auto rad = Angle.ToRadians();
-				auto xaxis = XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Axis));
-				auto xq = XMQuaternionRotationNormal(xaxis, rad.Value);
-				return reinterpret_cast<Quaternion&>(xq);
+				if (!std::is_constant_evaluated())
+				{
+					using namespace DirectX;
+					auto rad = Angle.ToRadians();
+					auto xaxis = XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Axis));
+					auto xq = XMQuaternionRotationNormal(xaxis, rad.Value);
+					Quaternion result;
+					XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&result), xq);
+					return result;
+				}
 			}
-			else
-			{
-				auto rad = Angle.ToRadians().Value;
-				T halfAngle = rad * T(0.5);
-				T s = Math::Sin(halfAngle);
-				T c = Math::Cos(halfAngle);
-				Vector3<T> axis = Vector<>::Normalize(Axis);
-				return Quaternion(axis * s, c);
-			}
+
+			auto rad = Angle.ToRadians().Value;
+			T halfAngle = rad * T(0.5);
+			T s = Math::Sin(halfAngle);
+			T c = Math::Cos(halfAngle);
+			Vector3<T> axis = Vector<>::Normalize(Axis);
+			return Quaternion(axis * s, c);
 		}
 
 		static Quaternion LookTo(const Vector3<T>& Forward, const Vector3<T>& Up)
 		{
-			if constexpr (std::same_as<T, float> && std::is_constant_evaluated())
+			if constexpr (std::same_as<T, float>)
 			{
-				using namespace DirectX;
-				auto xforward = XMVector3Normalize(XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Forward)));
-				auto xup = XMVector3Normalize(XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Up)));
-				auto xright = XMVector3Normalize(XMVector3Cross(xup, xforward));
-				xup = XMVector3Cross(xforward, xright);
+				if (!std::is_constant_evaluated())
+				{
+					using namespace DirectX;
+					auto xforward = XMVector3Normalize(XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Forward)));
+					auto xup = XMVector3Normalize(XMLoadFloat3(reinterpret_cast<const XMFLOAT3*>(&Up)));
+					auto xright = XMVector3Normalize(XMVector3Cross(xup, xforward));
+					xup = XMVector3Cross(xforward, xright);
 
-				XMMATRIX xm;
-				xm.r[0] = xright;
-				xm.r[1] = xup;
-				xm.r[2] = xforward;
-				xm.r[3] = XMVectorSet(0, 0, 0, 1);
+					XMMATRIX xm;
+					xm.r[0] = xright;
+					xm.r[1] = xup;
+					xm.r[2] = xforward;
+					xm.r[3] = XMVectorSet(0, 0, 0, 1);
 
-				auto xq = XMQuaternionRotationMatrix(xm);
-				return reinterpret_cast<Quaternion&>(xq);
+					auto xq = XMQuaternionRotationMatrix(xm);
+					Quaternion result;
+					XMStoreFloat4(reinterpret_cast<XMFLOAT4*>(&result), xq);
+					return result;
+				}
 			}
-			else
-			{
-				Vector3<T> f = Vector<>::Normalize(Forward);
-				Vector3<T> r = Vector<>::Normalize(Vector<>::Cross(Up, f));
-				Vector3<T> u = Vector<>::Cross(f, r);
 
-				Matrix4x4<T> m;
-				m[0][0] = r[0]; m[0][1] = r[1]; m[0][2] = r[2];
-				m[1][0] = u[0]; m[1][1] = u[1]; m[1][2] = u[2];
-				m[2][0] = f[0]; m[2][1] = f[1]; m[2][2] = f[2];
+			Vector3<T> f = Vector<>::Normalize(Forward);
+			Vector3<T> r = Vector<>::Normalize(Vector<>::Cross(Up, f));
+			Vector3<T> u = Vector<>::Cross(f, r);
 
-				return FromMatrix(m);
-			}
+			Matrix4x4<T> m;
+			m[0][0] = r[0]; m[0][1] = r[1]; m[0][2] = r[2];
+			m[1][0] = u[0]; m[1][1] = u[1]; m[1][2] = u[2];
+			m[2][0] = f[0]; m[2][1] = f[1]; m[2][2] = f[2];
+
+			return FromMatrix(m);
 		}
 
 		static Quaternion FromEulerAngles(const Vector3<T>& eulerAngles)

--- a/Engine/Source/Runtime/Numerics/Public/Numerics/TransformInterface/Quaternion.h
+++ b/Engine/Source/Runtime/Numerics/Public/Numerics/TransformInterface/Quaternion.h
@@ -451,7 +451,7 @@ namespace Ayla
 
 	template<class T>
 	template<TIsVector<T, 4> IQuaternion, TIsVector<T, 3> IVector>
-	static constexpr IVector Quaternion<T>::TransformVector(const IQuaternion& QW, const IVector& V)
+	constexpr IVector Quaternion<T>::TransformVector(const IQuaternion& QW, const IVector& V)
 	{
 		return Quaternion<>::TransformPoint<T>(QW, V);
 	}

--- a/Engine/Source/Runtime/RenderCore/Public/Misc/Geometry.h
+++ b/Engine/Source/Runtime/RenderCore/Public/Misc/Geometry.h
@@ -815,7 +815,7 @@ namespace Ayla
                 1, 3, 2,
             };
 
-            for ( size_t j = 0; j < _countof( faces ); j += 3 )
+            for ( size_t j = 0; j < AE_ARRAYSIZE( faces ); j += 3 )
             {
                 uint32_t v0 = faces[j];
                 uint32_t v1 = faces[j + 1];
@@ -880,7 +880,7 @@ namespace Ayla
                 5, 0, 3
             };
 
-            for (size_t j = 0; j < _countof(faces); j += 3)
+            for (size_t j = 0; j < AE_ARRAYSIZE(faces); j += 3)
             {
                 uint32_t v0 = faces[j];
                 uint32_t v1 = faces[j + 1];
@@ -995,7 +995,7 @@ namespace Ayla
             };
 
             size_t t = 0;
-            for ( size_t j = 0; j < _countof( faces ); j += 5, ++t )
+            for ( size_t j = 0; j < AE_ARRAYSIZE( faces ); j += 5, ++t )
             {
                 uint32_t v0 = faces[j];
                 uint32_t v1 = faces[j + 1];
@@ -1100,7 +1100,7 @@ namespace Ayla
                 11, 7, 5
             };
 
-            for (size_t j = 0; j < _countof(faces); j += 3)
+            for (size_t j = 0; j < AE_ARRAYSIZE(faces); j += 3)
             {
                 uint32_t v0 = faces[j];
                 uint32_t v1 = faces[j + 1];
@@ -1185,7 +1185,7 @@ namespace Ayla
             XMVECTOR scaleNegateZ = XMVectorMultiply(scaleVector, g_XMNegateZ);
             XMVECTOR scaleNegateXZ = XMVectorMultiply(scaleVector, XMVectorMultiply(g_XMNegateX, g_XMNegateZ));
 
-            for (size_t i = 0; i < _countof(TeapotPatches); i++)
+            for (size_t i = 0; i < AE_ARRAYSIZE(TeapotPatches); i++)
             {
                 TeapotPatch const& patch = TeapotPatches[i];
 

--- a/Engine/Source/Runtime/RenderCore/Public/Misc/VertexHelper.h
+++ b/Engine/Source/Runtime/RenderCore/Public/Misc/VertexHelper.h
@@ -9,6 +9,14 @@ namespace Ayla
 {
 	namespace GeometryHelper
 	{
+#if defined(_MSC_VER)
+		template<class T>
+		concept IsDirectXVector = std::convertible_to<T, DirectX::XMVECTOR> || std::convertible_to<T, DirectX::XMVECTORF32>;
+#else
+		template<class T>
+		concept IsDirectXVector = std::convertible_to<T, DirectX::XMVECTORF32>;
+#endif
+
 		template<class T>
 		concept IsMutableVector2 = requires (T & v)
 		{
@@ -21,7 +29,7 @@ namespace Ayla
 		};
 
 		template<class T>
-		concept IsVector2 = IsMutableVector2<T> || std::convertible_to<T, DirectX::XMVECTOR> || std::convertible_to<T, DirectX::XMVECTORF32>;
+		concept IsVector2 = IsMutableVector2<T> || IsDirectXVector<T>;
 
 		template<class T>
 		concept IsMutableVector3 = requires (T & v)
@@ -37,7 +45,7 @@ namespace Ayla
 		};
 
 		template<class T>
-		concept IsVector3 = IsMutableVector3<T> || std::convertible_to<T, DirectX::XMVECTOR> || std::convertible_to<T, DirectX::XMVECTORF32>;
+		concept IsVector3 = IsMutableVector3<T> || IsDirectXVector<T>;
 
 		template<class T>
 		concept IsVertex = requires (T & v)

--- a/Engine/Source/Runtime/RenderCore/Public/Misc/VertexHelper.h
+++ b/Engine/Source/Runtime/RenderCore/Public/Misc/VertexHelper.h
@@ -9,13 +9,13 @@ namespace Ayla
 {
 	namespace GeometryHelper
 	{
-#if defined(_MSC_VER)
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wignored-attributes"
+#endif
+
 		template<class T>
 		concept IsDirectXVector = std::convertible_to<T, DirectX::XMVECTOR> || std::convertible_to<T, DirectX::XMVECTORF32>;
-#else
-		template<class T>
-		concept IsDirectXVector = std::convertible_to<T, DirectX::XMVECTORF32>;
-#endif
 
 		template<class T>
 		concept IsMutableVector2 = requires (T & v)
@@ -46,6 +46,10 @@ namespace Ayla
 
 		template<class T>
 		concept IsVector3 = IsMutableVector3<T> || IsDirectXVector<T>;
+
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 		template<class T>
 		concept IsVertex = requires (T & v)

--- a/Engine/Source/Runtime/RenderCore/Public/Rendering/ShaderCreationInfo.h
+++ b/Engine/Source/Runtime/RenderCore/Public/Rendering/ShaderCreationInfo.h
@@ -10,16 +10,16 @@ namespace Ayla
 {
 	struct ShaderCreationInfo
 	{
-		std::shared_ptr<VertexFactory> VertexFactory;
-		ShaderBytecode VertexShader;
-		ShaderBytecode FragmentShader;
-		ShaderBytecode DomainShader;
-		ShaderBytecode HullShader;
-		ShaderBytecode GeometryShader;
-		ShaderBytecode ComputeShader;
-		ShaderBytecode RayGenerationShader;
-		ShaderBytecode ClosestHitShader;
-		ShaderBytecode AnyHitShader;
-		ShaderBytecode MissShader;
+		std::shared_ptr<VertexFactory> m_VertexFactory;
+		ShaderBytecode m_VertexShader;
+		ShaderBytecode m_FragmentShader;
+		ShaderBytecode m_DomainShader;
+		ShaderBytecode m_HullShader;
+		ShaderBytecode m_GeometryShader;
+		ShaderBytecode m_ComputeShader;
+		ShaderBytecode m_RayGenerationShader;
+		ShaderBytecode m_ClosestHitShader;
+		ShaderBytecode m_AnyHitShader;
+		ShaderBytecode m_MissShader;
 	};
 }

--- a/Engine/Source/Runtime/VulkanAPI/Private/VkCommon.h
+++ b/Engine/Source/Runtime/VulkanAPI/Private/VkCommon.h
@@ -79,10 +79,14 @@ public:
         this->Reset();
     }
 
-    template<class TSelf>
-    inline auto Get(this TSelf&& self) noexcept
+    inline T Get() noexcept
     {
-        return self.m_Ptr;
+        return m_Ptr;
+    }
+
+    inline T Get() const noexcept
+    {
+        return m_Ptr;
     }
 
     inline void Reset() noexcept
@@ -100,8 +104,8 @@ public:
         return &m_Ptr;
     }
 
-    template<class TSelf>
-    inline auto operator ->(this TSelf&& self) noexcept { return self.Get(); }
+    inline T operator ->() noexcept { return Get(); }
+    inline T operator ->() const noexcept { return Get(); }
 
     inline VkRef& operator =(VkRef&& rhs) noexcept
     {

--- a/Engine/Source/Runtime/VulkanAPI/Private/VkGraphics.cpp
+++ b/Engine/Source/Runtime/VulkanAPI/Private/VkGraphics.cpp
@@ -51,10 +51,12 @@ namespace Ayla
             "VK_KHR_get_physical_device_properties2"
         };
 
-        std::vector<const char*> extensions =
-            std::ranges::to<std::vector<const char*>>(
-                app.GetVulkanExtensionNames() | Linq::Concat(kExtensions)
-            );
+        auto extensionNames = app.GetVulkanExtensionNames() | Linq::Concat(kExtensions);
+        std::vector<const char*> extensions;
+        for (const char* extensionName : extensionNames)
+        {
+            extensions.emplace_back(extensionName);
+        }
         
         VkInstanceCreateInfo vkInstanceCreateInfo =
         {

--- a/Engine/Source/Runtime/VulkanAPI/Private/VkShader.cpp
+++ b/Engine/Source/Runtime/VulkanAPI/Private/VkShader.cpp
@@ -16,7 +16,7 @@ namespace Ayla
 
 	VertexFactory* VkShader::GetVertexFactory() const
 	{
-		return m_CreationInfo.VertexFactory.get();
+		return m_CreationInfo.m_VertexFactory.get();
 	}
 
 	bool VkShader::Has(ShaderType type) const
@@ -24,25 +24,25 @@ namespace Ayla
 		switch (type)
 		{
 		case ShaderType::Vertex:
-			return !m_CreationInfo.VertexShader.Bytecode.empty();
+			return !m_CreationInfo.m_VertexShader.Bytecode.empty();
 		case ShaderType::Pixel:
-			return !m_CreationInfo.FragmentShader.Bytecode.empty();
+			return !m_CreationInfo.m_FragmentShader.Bytecode.empty();
 		case ShaderType::Domain:
-			return !m_CreationInfo.DomainShader.Bytecode.empty();
+			return !m_CreationInfo.m_DomainShader.Bytecode.empty();
 		case ShaderType::Hull:
-			return !m_CreationInfo.HullShader.Bytecode.empty();
+			return !m_CreationInfo.m_HullShader.Bytecode.empty();
 		case ShaderType::Geometry:
-			return !m_CreationInfo.GeometryShader.Bytecode.empty();
+			return !m_CreationInfo.m_GeometryShader.Bytecode.empty();
 		case ShaderType::Compute:
-			return !m_CreationInfo.ComputeShader.Bytecode.empty();
+			return !m_CreationInfo.m_ComputeShader.Bytecode.empty();
 		case ShaderType::RayGeneration:
-			return !m_CreationInfo.RayGenerationShader.Bytecode.empty();
+			return !m_CreationInfo.m_RayGenerationShader.Bytecode.empty();
 		case ShaderType::ClosestHit:
-			return !m_CreationInfo.ClosestHitShader.Bytecode.empty();
+			return !m_CreationInfo.m_ClosestHitShader.Bytecode.empty();
 		case ShaderType::AnyHit:
-			return !m_CreationInfo.AnyHitShader.Bytecode.empty();
+			return !m_CreationInfo.m_AnyHitShader.Bytecode.empty();
 		case ShaderType::Miss:
-			return !m_CreationInfo.MissShader.Bytecode.empty();
+			return !m_CreationInfo.m_MissShader.Bytecode.empty();
 		default:
 			return false;
 		}
@@ -53,25 +53,25 @@ namespace Ayla
 		switch (type)
 		{
 		case ShaderType::Vertex:
-			return m_CreationInfo.VertexShader;
+			return m_CreationInfo.m_VertexShader;
 		case ShaderType::Pixel:
-			return m_CreationInfo.FragmentShader;
+			return m_CreationInfo.m_FragmentShader;
 		case ShaderType::Domain:
-			return m_CreationInfo.DomainShader;
+			return m_CreationInfo.m_DomainShader;
 		case ShaderType::Hull:
-			return m_CreationInfo.HullShader;
+			return m_CreationInfo.m_HullShader;
 		case ShaderType::Geometry:
-			return m_CreationInfo.GeometryShader;
+			return m_CreationInfo.m_GeometryShader;
 		case ShaderType::Compute:
-			return m_CreationInfo.ComputeShader;
+			return m_CreationInfo.m_ComputeShader;
 		case ShaderType::RayGeneration:
-			return m_CreationInfo.RayGenerationShader;
+			return m_CreationInfo.m_RayGenerationShader;
 		case ShaderType::ClosestHit:
-			return m_CreationInfo.ClosestHitShader;
+			return m_CreationInfo.m_ClosestHitShader;
 		case ShaderType::AnyHit:
-			return m_CreationInfo.AnyHitShader;
+			return m_CreationInfo.m_AnyHitShader;
 		case ShaderType::Miss:
-			return m_CreationInfo.MissShader;
+			return m_CreationInfo.m_MissShader;
 		default:
 			throw InvalidOperationException(TEXT("Invalid shader type."));
 		}


### PR DESCRIPTION
## Summary
- Restore compile-only CI coverage across Windows, macOS, and Ubuntu without requiring ShaderCompileWorker or Vulkan SDK setup.
- Fix cross-platform C++ portability issues found by clang/GCC/MSVC, including Unix sockets, SAL/_countof portability, const reflection signatures, stacktrace formatting, DirectXMath comparisons, and geometry helper warnings.
- Add real Unix socket async backends: Linux uses io_uring and macOS uses a kqueue-based one-shot operation queue.
- Keep Actions runtime updates for Node 24 readiness while removing branch-only CI triggers before merge into dev.

## Validation
- `git diff --check`
- `dotnet Engine/Binaries/DotNET/AylaBuildTool.dll build --target "Engine" --config Shipping --skip-shaders`
- GitHub Actions before final CI-trigger cleanup: Windows, macOS, and Ubuntu passed in https://github.com/Aumoa/CPP.REF/actions/runs/27095486316
- Final cleanup commit removes only task-branch validation triggers from `.github/workflows/ci.yml`; local compile-only validation was rerun after that cleanup.

## Notes
- Shader compilation is still skipped in CI with `--skip-shaders`; this keeps the compile-only path independent from Vulkan SDK and DXC setup.
- The Unix async socket backend is now functional enough for compile coverage and basic async operation routing, but deeper socket behavior work such as cancellation policy, partial transfer semantics, and backend file splitting should be handled separately.