### PR TITLE
Codex: Support Visual Studio 2026 detection

### DIFF
--- a/Engine/Source/Programs/AylaBuildTool/Installations/VisualStudio/VisualStudioInstallation.cs
+++ b/Engine/Source/Programs/AylaBuildTool/Installations/VisualStudio/VisualStudioInstallation.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Nodes;
+﻿using System.Diagnostics;
+using System.Text.Json.Nodes;
 
 namespace AylaEngine;
 
@@ -52,12 +53,6 @@ internal class VisualStudioInstallation : Installation
 
     static VisualStudioInstallation()
     {
-        if (Directory.Exists(VSRoot) == false)
-        {
-            s_Products = Array.Empty<Product>();
-            return;
-        }
-
         List<Version> kitVersions = [];
         if (Directory.Exists(Path.Combine(KitRoot, "Include")) == false)
         {
@@ -89,70 +84,238 @@ internal class VisualStudioInstallation : Installation
         kitVersions.Sort((l, r) => r.CompareTo(l));
         s_WindowsKitVersion = kitVersions.First();
 
-        List<Product> products = [];
-        foreach (var visualStudioVersionDirectory in Directory.GetDirectories(VSRoot))
-        {
-            VSVersion visualStudioVersion;
-            switch (Path.GetFileName(visualStudioVersionDirectory))
-            {
-                case "2022":
-                    visualStudioVersion = VSVersion._2022;
-                    break;
-                case "2026":
-                case "18":
-                    visualStudioVersion = VSVersion._2026;
-                    break;
-                default:
-                    continue;
-            }
-
-            foreach (var licenseDirectory in Directory.GetDirectories(visualStudioVersionDirectory))
-            {
-                if (Enum.TryParse<License>(Path.GetFileName(licenseDirectory), out var license) == false)
-                {
-                    continue;
-                }
-
-                CheckFolder(license, licenseDirectory);
-            }
-
-            CheckFolder(License.BuildTool, visualStudioVersionDirectory);
-            continue;
-
-            void CheckFolder(License license, string folder)
-            {
-                var msvc = Path.Combine(folder, "VC", "Tools", "MSVC");
-                if (Directory.Exists(msvc) == false)
-                {
-                    return;
-                }
-
-                foreach (var versionDir in Directory.GetDirectories(msvc))
-                {
-                    var versionStr = Path.GetFileName(versionDir);
-                    if (Version.TryParse(versionStr, out var version) == false)
-                    {
-                        continue;
-                    }
-
-                    products.Add(new Product
-                    {
-                        License = license,
-                        VisualStudioVersion = visualStudioVersion,
-                        CompilerVersion = version,
-                        Directory = versionDir
-                    });
-                }
-            }
-        }
-
-        products.Sort((l, r) => r.CompilerVersion.CompareTo(l.CompilerVersion));
+        var products = DiscoverProducts();
+        products.Sort(CompareProducts);
         s_Products = products.ToArray();
         if (s_Products.Length == 0)
         {
             s_WindowsKitVersion = null;
         }
     }
+
+    private static List<Product> DiscoverProducts()
+    {
+        var products = DiscoverProductsWithVswhere();
+        if (products.Count > 0)
+        {
+            return products;
+        }
+
+        return DiscoverProductsFromKnownFolders();
+    }
+
+    private static List<Product> DiscoverProductsWithVswhere()
+    {
+        List<Product> products = [];
+
+        var programFilesX86 = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
+        if (string.IsNullOrWhiteSpace(programFilesX86))
+        {
+            return products;
+        }
+
+        var vswhere = Path.Combine(programFilesX86, "Microsoft Visual Studio", "Installer", "vswhere.exe");
+        if (File.Exists(vswhere) == false)
+        {
+            return products;
+        }
+
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = vswhere,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            startInfo.ArgumentList.Add("-all");
+            startInfo.ArgumentList.Add("-prerelease");
+            startInfo.ArgumentList.Add("-products");
+            startInfo.ArgumentList.Add("*");
+            startInfo.ArgumentList.Add("-format");
+            startInfo.ArgumentList.Add("json");
+
+            using var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                return products;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output))
+            {
+                return products;
+            }
+
+            var instances = JsonNode.Parse(output)?.AsArray();
+            if (instances == null)
+            {
+                return products;
+            }
+
+            foreach (var instance in instances)
+            {
+                var installationDirectory = ReadString(instance?["installationPath"]);
+                if (string.IsNullOrWhiteSpace(installationDirectory))
+                {
+                    continue;
+                }
+
+                var catalog = instance?["catalog"];
+                var visualStudioVersion = ParseVisualStudioVersion(
+                    ReadString(catalog?["productLineVersion"]),
+                    ReadString(catalog?["productLine"]),
+                    ReadString(instance?["installationVersion"]),
+                    Path.GetFileName(Path.GetDirectoryName(installationDirectory)),
+                    Path.GetFileName(installationDirectory));
+                if (visualStudioVersion == null)
+                {
+                    continue;
+                }
+
+                var license = ParseLicense(ReadString(instance?["productId"]), installationDirectory);
+                AddProductsFromInstallationDirectory(products, license, visualStudioVersion.Value, installationDirectory);
+            }
+        }
+        catch
+        {
+            products.Clear();
+        }
+
+        return products;
+    }
+
+    private static List<Product> DiscoverProductsFromKnownFolders()
+    {
+        List<Product> products = [];
+        if (Directory.Exists(VSRoot) == false)
+        {
+            return products;
+        }
+
+        foreach (var visualStudioVersionDirectory in Directory.GetDirectories(VSRoot))
+        {
+            var visualStudioVersion = ParseVisualStudioVersion(Path.GetFileName(visualStudioVersionDirectory));
+            if (visualStudioVersion == null)
+            {
+                continue;
+            }
+
+            foreach (var licenseDirectory in Directory.GetDirectories(visualStudioVersionDirectory))
+            {
+                var license = ParseLicense(null, licenseDirectory);
+                AddProductsFromInstallationDirectory(products, license, visualStudioVersion.Value, licenseDirectory);
+            }
+
+            AddProductsFromInstallationDirectory(products, License.BuildTool, visualStudioVersion.Value, visualStudioVersionDirectory);
+        }
+
+        return products;
+    }
+
+    private static void AddProductsFromInstallationDirectory(List<Product> products, License license, VSVersion visualStudioVersion, string installationDirectory)
+    {
+        var msvc = Path.Combine(installationDirectory, "VC", "Tools", "MSVC");
+        if (Directory.Exists(msvc) == false)
+        {
+            return;
+        }
+
+        foreach (var versionDir in Directory.GetDirectories(msvc))
+        {
+            var versionStr = Path.GetFileName(versionDir);
+            if (Version.TryParse(versionStr, out var version) == false)
+            {
+                continue;
+            }
+
+            products.Add(new Product
+            {
+                License = license,
+                VisualStudioVersion = visualStudioVersion,
+                CompilerVersion = version,
+                Directory = versionDir
+            });
+        }
+    }
+
+    private static int CompareProducts(Product l, Product r)
+    {
+        var visualStudioVersionCompare = GetVisualStudioVersionRank(r.VisualStudioVersion).CompareTo(GetVisualStudioVersionRank(l.VisualStudioVersion));
+        if (visualStudioVersionCompare != 0)
+        {
+            return visualStudioVersionCompare;
+        }
+
+        return r.CompilerVersion.CompareTo(l.CompilerVersion);
+    }
+
+    private static int GetVisualStudioVersionRank(VSVersion value) => value switch
+    {
+        VSVersion._2026 => 2026,
+        VSVersion._2022 => 2022,
+        _ => 0
+    };
+
+    private static License ParseLicense(string? productId, string installationDirectory)
+    {
+        if (productId?.EndsWith(".BuildTools", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            return License.BuildTool;
+        }
+
+        foreach (var license in Enum.GetValues<License>())
+        {
+            if (productId?.EndsWith("." + license, StringComparison.OrdinalIgnoreCase) == true)
+            {
+                return license;
+            }
+        }
+
+        if (Enum.TryParse<License>(Path.GetFileName(installationDirectory), true, out var parsedLicense))
+        {
+            return parsedLicense;
+        }
+
+        return License.Community;
+    }
+
+    private static VSVersion? ParseVisualStudioVersion(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            if (value.Equals("2026", StringComparison.OrdinalIgnoreCase) ||
+                value.Equals("18", StringComparison.OrdinalIgnoreCase) ||
+                value.Equals("Dev18", StringComparison.OrdinalIgnoreCase) ||
+                value.StartsWith("18.", StringComparison.OrdinalIgnoreCase))
+            {
+                return VSVersion._2026;
+            }
+
+            if (value.Equals("2022", StringComparison.OrdinalIgnoreCase) ||
+                value.Equals("17", StringComparison.OrdinalIgnoreCase) ||
+                value.Equals("Dev17", StringComparison.OrdinalIgnoreCase) ||
+                value.StartsWith("17.", StringComparison.OrdinalIgnoreCase))
+            {
+                return VSVersion._2022;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? ReadString(JsonNode? node) => node?.GetValue<string>();
 
     public static VSVersion? DetectedVersion => s_Products.Length > 0 ? s_Products[0].VisualStudioVersion : null;
 

--- a/Engine/Source/Programs/AylaBuildTool/Installations/VisualStudio/VisualStudioInstallation.cs
+++ b/Engine/Source/Programs/AylaBuildTool/Installations/VisualStudio/VisualStudioInstallation.cs
@@ -95,13 +95,13 @@ internal class VisualStudioInstallation : Installation
 
     private static List<Product> DiscoverProducts()
     {
-        var products = DiscoverProductsWithVswhere();
+        var products = DiscoverProductsFromKnownFolders();
         if (products.Count > 0)
         {
             return products;
         }
 
-        return DiscoverProductsFromKnownFolders();
+        return DiscoverProductsWithVswhere();
     }
 
     private static List<Product> DiscoverProductsWithVswhere()


### PR DESCRIPTION
## Summary

- Detect Visual Studio 2026 Insiders installations during Visual Studio project generation.
- Prefer standard Visual Studio install folder probing before invoking vswhere.
- Keep vswhere as a fallback for non-standard Visual Studio installation layouts.

## Validation

- dotnet build Engine\\Source\\Programs\\AylaBuildTool\\AylaBuildTool.csproj
- dotnet Engine\\Binaries\\DotNET\\AylaBuildTool.dll generate --project SampleGame\\SampleGame.aproject
- Confirmed generated SampleGame solution uses Visual Studio Version 18.
- Confirmed generated GameAssembly vcxproj uses VCProjectVersion 18.0 and PlatformToolset v144.
- git diff --check

## Notes

vswhere is only used as a fallback after standard folder probing fails, so common project generation paths avoid launching an external process.